### PR TITLE
API doesn't allow null manager_id

### DIFF
--- a/SnipeitPS/Public/New-User.ps1
+++ b/SnipeitPS/Public/New-User.ps1
@@ -107,12 +107,13 @@ function New-User() {
         company_id    = $company_id
         location_id   = $location_id
         department_id = $department_id
-        manager_id    = $manager_id
         jobtitle      = $jobTitle
         employee_num  = $employee_num
         notes         = "Imported using SnipeitPS Script"
         activated     = 1
     }
+
+    if ($manager_id) {$Values.manager_id = $manager_id}
 
     if ($ldap_user -eq $false) {
         $ldap = @{


### PR DESCRIPTION
Currently the New-User is sending a '0' to the API when a null value for manager_id is issued via parameters. I've added a bit of logic to only add the manager_id to the $values HT when there is an actual value provided to the cmdlet.

Sorry if this is not right, this is my first ever contribution. :)