### PR TITLE
If api request to snipe  fails, don't continue, just throw error

### DIFF
--- a/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
+++ b/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
@@ -72,8 +72,9 @@
             $webResponse = Invoke-WebRequest @splatParameters
         }
         catch {
-            Write-Verbose "[$($MyInvocation.MyCommand.Name)] Failed to get an answer from the server"
-            $webResponse = $_.Exception.Response
+            #Write-Verbose "[$($MyInvocation.MyCommand.Name)] Failed to get an answer from the server"
+            #$webResponse = $_.Exception.Response
+            throw "[$($MyInvocation.MyCommand.Name)] Failed to get an answer from the server. $($_.Exception.Response)"
         }
 
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Executed WebRequest. Access $webResponse to see details"


### PR DESCRIPTION
Simple fix for #91 more meaningful error messages 