### PR TITLE
PSReviewUnusedParameter does not detect our variables well

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -3,6 +3,7 @@
     # IncludeRules = @()
     ExcludeRules = @(
         'PSAvoidUsingUserNameAndPassWordParams',
-        'PSAvoidUsingPlainTextForPassword'
+        'PSAvoidUsingPlainTextForPassword',
+        'PSReviewUnusedParameter'
     )
 }


### PR DESCRIPTION
Current peaster tests complains a lot about unused variables. Most of function parameters are used like
```powershell
$Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
```
so 'PSReviewUnusedParameter' test does not detect those correctly. 

As I see  we could disable that test.
