### PR TITLE
Pass PSBoundParameters

### DIFF
--- a/SnipeitPS/Private/Get-ParameterValue.ps1
+++ b/SnipeitPS/Private/Get-ParameterValue.ps1
@@ -25,6 +25,8 @@ function Get-ParameterValue {
         [parameter(mandatory = $true)]
         $Parameters
         ,
+        [parameter(mandatory = $true)]
+        $BoundParameters,
 
         [string[]]$DefaultExcludeParameter = @("id", "url", "apiKey", 'Debug', 'Verbose','RequestType','customfields')
     )
@@ -40,10 +42,15 @@ function Get-ParameterValue {
         try {
             $key = $parameter.Key
             if ($key -notin $DefaultExcludeParameter) {
+                #Fill in default parameters values
                 if ($null -ne ($value = Get-Variable -Name $key -ValueOnly -ErrorAction Ignore )) {
                     if ($value -ne ($null -as $parameter.Value.ParameterType)) {
                         $ParameterValues[$key] = $value
                     }
+                }
+                #Fill in all given parameters even empty
+                if ($BoundParameters.ContainsKey($key)) {
+                    $ParameterValues[$key] = $BoundParameters[$key]
                 }
 
             }

--- a/SnipeitPS/Public/Get-SnipeItAccessory.ps1
+++ b/SnipeitPS/Public/Get-SnipeItAccessory.ps1
@@ -65,7 +65,7 @@ function Get-SnipeItAccessory() {
     )
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $Parameters = @{
         Uri           = "$url/api/v1/accessories"

--- a/SnipeitPS/Public/Get-SnipeItActivity.ps1
+++ b/SnipeitPS/Public/Get-SnipeItActivity.ps1
@@ -88,7 +88,7 @@ function Get-SnipeItActivity() {
         throw "Please specify both item_type and item_id"
     }
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
 
     $Parameters = @{

--- a/SnipeitPS/Public/Get-SnipeItAsset.ps1
+++ b/SnipeitPS/Public/Get-SnipeItAsset.ps1
@@ -120,7 +120,7 @@ function Get-SnipeItAsset() {
     )
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
 
     $apiurl = "$url/api/v1/hardware"

--- a/SnipeitPS/Public/Get-SnipeItAssetMaintenance.ps1
+++ b/SnipeitPS/Public/Get-SnipeItAssetMaintenance.ps1
@@ -64,7 +64,7 @@ function Get-SnipeItAssetMaintenance() {
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $Parameters = @{
         Uri           = "$url/api/v1/maintenances"

--- a/SnipeitPS/Public/Get-SnipeItCategory.ps1
+++ b/SnipeitPS/Public/Get-SnipeItCategory.ps1
@@ -55,7 +55,7 @@ function Get-SnipeItCategory()
     )
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $apiurl = "$url/api/v1/categories"
 

--- a/SnipeitPS/Public/Get-SnipeItCompany.ps1
+++ b/SnipeitPS/Public/Get-SnipeItCompany.ps1
@@ -57,7 +57,7 @@ function Get-SnipeItCompany()
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $apiurl = "$url/api/v1/companies"
 

--- a/SnipeitPS/Public/Get-SnipeItComponent.ps1
+++ b/SnipeitPS/Public/Get-SnipeItComponent.ps1
@@ -70,7 +70,7 @@ function Get-SnipeItComponent() {
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $apiurl = "$url/api/v1/components"
 

--- a/SnipeitPS/Public/Get-SnipeItDepartment.ps1
+++ b/SnipeitPS/Public/Get-SnipeItDepartment.ps1
@@ -62,7 +62,7 @@ function Get-SnipeItDepartment()
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $apiurl = "$url/api/v1/departments"
 

--- a/SnipeitPS/Public/Get-SnipeItLicense.ps1
+++ b/SnipeitPS/Public/Get-SnipeItLicense.ps1
@@ -81,7 +81,7 @@ function Get-SnipeItLicense() {
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $apiurl = "$url/api/v1/licenses"
 

--- a/SnipeitPS/Public/Get-SnipeItLicenseSeat.ps1
+++ b/SnipeitPS/Public/Get-SnipeItLicenseSeat.ps1
@@ -56,7 +56,7 @@ function Get-SnipeItLicenseSeat() {
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $apiurl = "$url/api/v1/licenses/$id/seats"
 

--- a/SnipeitPS/Public/Get-SnipeItLocation.ps1
+++ b/SnipeitPS/Public/Get-SnipeItLocation.ps1
@@ -56,7 +56,7 @@ function Get-SnipeitLocation()
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $apiurl = "$url/api/v1/locations"
 

--- a/SnipeitPS/Public/Get-SnipeItManufacturer.ps1
+++ b/SnipeitPS/Public/Get-SnipeItManufacturer.ps1
@@ -58,7 +58,7 @@ function Get-SnipeItManufacturer()
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $apiurl = "$url/api/v1/manufacturers"
 

--- a/SnipeitPS/Public/Get-SnipeItModel.ps1
+++ b/SnipeitPS/Public/Get-SnipeItModel.ps1
@@ -56,7 +56,7 @@ function Get-SnipeItModel()
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $apiurl = "$url/api/v1/models"
 

--- a/SnipeitPS/Public/Get-SnipeItStatus.ps1
+++ b/SnipeitPS/Public/Get-SnipeItStatus.ps1
@@ -56,7 +56,7 @@ function Get-SnipeItStatus()
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $apiurl = "$url/api/v1/statuslabels"
 

--- a/SnipeitPS/Public/Get-SnipeItSupplier.ps1
+++ b/SnipeitPS/Public/Get-SnipeItSupplier.ps1
@@ -56,7 +56,7 @@ function Get-SnipeItSupplier()
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $apiurl = "$url/api/v1/suppliers"
 

--- a/SnipeitPS/Public/Get-SnipeItUser.ps1
+++ b/SnipeitPS/Public/Get-SnipeItUser.ps1
@@ -78,7 +78,7 @@ function Get-SnipeItUser() {
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $apiurl = "$url/api/v1/users"
 

--- a/SnipeitPS/Public/New-SnipeItAccessory.ps1
+++ b/SnipeitPS/Public/New-SnipeItAccessory.ps1
@@ -107,7 +107,7 @@ function New-SnipeItAccessory() {
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     if ($values['purchase_date']) {
         $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")

--- a/SnipeitPS/Public/New-SnipeItAsset.ps1
+++ b/SnipeitPS/Public/New-SnipeItAsset.ps1
@@ -125,7 +125,7 @@ function New-SnipeItAsset()
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     if ($values['purchase_date']) {
         $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")

--- a/SnipeitPS/Public/New-SnipeItAssetMaintenance.ps1
+++ b/SnipeitPS/Public/New-SnipeItAssetMaintenance.ps1
@@ -79,7 +79,7 @@ function New-SnipeItAssetMaintenance() {
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     if ($values['start_date']) {
         $values['start_date'] = $values['start_date'].ToString("yyyy-MM-dd")

--- a/SnipeitPS/Public/New-SnipeItCompany.ps1
+++ b/SnipeitPS/Public/New-SnipeItCompany.ps1
@@ -39,7 +39,7 @@ function New-SnipeItCompany()
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $Body = $Values | ConvertTo-Json;
 

--- a/SnipeitPS/Public/New-SnipeItComponent.ps1
+++ b/SnipeitPS/Public/New-SnipeItComponent.ps1
@@ -69,7 +69,7 @@ function New-SnipeItComponent() {
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     if ($values['purchase_date']) {
         $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")

--- a/SnipeitPS/Public/New-SnipeItCustomField.ps1
+++ b/SnipeitPS/Public/New-SnipeItCustomField.ps1
@@ -48,7 +48,7 @@ function New-SnipeItCustomField()
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     #Convert Values to JSON format
     $Body = $Values | ConvertTo-Json;

--- a/SnipeitPS/Public/New-SnipeItDepartment.ps1
+++ b/SnipeitPS/Public/New-SnipeItDepartment.ps1
@@ -55,7 +55,7 @@ function New-SnipeItDepartment() {
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $Body = $Values | ConvertTo-Json;
 

--- a/SnipeitPS/Public/New-SnipeItLicense.ps1
+++ b/SnipeitPS/Public/New-SnipeItLicense.ps1
@@ -126,7 +126,7 @@ function New-SnipeItLicense() {
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     if ($values['expiration_date']) {
         $values['expiration_date'] = $values['expiration_date'].ToString("yyyy-MM-dd")

--- a/SnipeitPS/Public/New-SnipeItLocation.ps1
+++ b/SnipeitPS/Public/New-SnipeItLocation.ps1
@@ -87,7 +87,7 @@ function New-SnipeItLocation() {
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $Body = $Values | ConvertTo-Json;
 

--- a/SnipeitPS/Public/New-SnipeItUser.ps1
+++ b/SnipeitPS/Public/New-SnipeItUser.ps1
@@ -111,7 +111,7 @@ function New-SnipeItUser() {
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     if ($password ) {
             $Values['password_confirmation'] = $password

--- a/SnipeitPS/Public/Set-SnipeItAccessory.ps1
+++ b/SnipeitPS/Public/Set-SnipeItAccessory.ps1
@@ -106,7 +106,7 @@ function Set-SnipeItAccessory() {
     begin {
         Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-        $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
         if ($values['purchase_date']) {
             $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")

--- a/SnipeitPS/Public/Set-SnipeItAccessoryOwner.ps1
+++ b/SnipeitPS/Public/Set-SnipeItAccessoryOwner.ps1
@@ -45,7 +45,7 @@ function Set-SnipeItAccessoryOwner()
         [string]$apiKey
     )
     begin{
-        $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
         $Body = $Values | ConvertTo-Json;
     }

--- a/SnipeitPS/Public/Set-SnipeItAsset.ps1
+++ b/SnipeitPS/Public/Set-SnipeItAsset.ps1
@@ -130,7 +130,7 @@ function Set-SnipeItAsset()
     begin{
         Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-        $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
         if ($values['purchase_date']) {
             $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")

--- a/SnipeitPS/Public/Set-SnipeItAssetOwner.ps1
+++ b/SnipeitPS/Public/Set-SnipeItAssetOwner.ps1
@@ -68,7 +68,7 @@ function Set-SnipeItAssetOwner()
     begin{
         Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-        $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
         if ($Values['expected_checkin']) {
             $Values['expected_checkin'] = $values['expected_checkin'].ToString("yyyy-MM-dd")

--- a/SnipeitPS/Public/Set-SnipeItComponents.ps1
+++ b/SnipeitPS/Public/Set-SnipeItComponents.ps1
@@ -71,7 +71,7 @@ function Set-SnipeItComponent()
 
     Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+    $values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     if ($values['purchase_date']) {
         $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")

--- a/SnipeitPS/Public/Set-SnipeItLicense.ps1
+++ b/SnipeitPS/Public/Set-SnipeItLicense.ps1
@@ -131,7 +131,7 @@ function Set-SnipeItLicense() {
     begin{
         Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-        $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
         if ($values['expiration_date']) {
             $values['expiration_date'] = $values['expiration_date'].ToString("yyyy-MM-dd")

--- a/SnipeitPS/Public/Set-SnipeItLicenseSeat.ps1
+++ b/SnipeitPS/Public/Set-SnipeItLicenseSeat.ps1
@@ -59,7 +59,7 @@ function Set-SnipeItLicenseSeat()
     )
 
     begin{
-        $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
         $Body = $Values | ConvertTo-Json;
     }

--- a/SnipeitPS/Public/Set-SnipeItLocation.ps1
+++ b/SnipeitPS/Public/Set-SnipeItLocation.ps1
@@ -98,7 +98,7 @@ function Set-SnipeitLocation() {
     begin{
         Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-        $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
         $Body = $Values | ConvertTo-Json;
     }

--- a/SnipeitPS/Public/Set-SnipeItModel.ps1
+++ b/SnipeitPS/Public/Set-SnipeItModel.ps1
@@ -69,7 +69,7 @@ function Set-SnipeItModel() {
     begin {
         Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-        $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
         $Body = $Values | ConvertTo-Json;
     }

--- a/SnipeitPS/Public/Set-SnipeItUser.ps1
+++ b/SnipeitPS/Public/Set-SnipeItUser.ps1
@@ -109,7 +109,7 @@ function Set-SnipeItUser() {
     begin{
         Test-SnipeItAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-        $Values = . Get-ParameterValue $MyInvocation.MyCommand.Parameters
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
         $Body = $Values | ConvertTo-Json;
     }


### PR DESCRIPTION
In resent powershell 7 compatibility fix I overlooked PSBoundParameters. Without that information is not possible to pass empty parameter values back to calling function. 