### PR TITLE
use nullable ints

### DIFF
--- a/SnipeitPS/Public/Set-SnipeitLicenseSeat.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLicenseSeat.ps1
@@ -46,9 +46,9 @@ function Set-SnipeitLicenseSeat()
         [int]$seat_id,
 
         [Alias('assigned_id')]
-        [int]$assigned_to,
+        [Nullable[System.Int32]]$assigned_to,
 
-        [int]$asset_id,
+        [Nullable[System.Int32]]$asset_id,
 
         [string]$note,
 


### PR DESCRIPTION
This will allow null values to sent to snipe instead of zeros.