### PR TITLE
Allow set values to $null

### DIFF
--- a/SnipeitPS/Public/New-SnipeitUser.ps1
+++ b/SnipeitPS/Public/New-SnipeitUser.ps1
@@ -17,6 +17,9 @@
     .PARAMETER active
     Can user log in to snipe-it?
 
+    .PARAMETER password
+    Password for user
+
     .PARAMETER notes
     User Notes
 

--- a/SnipeitPS/Public/Set-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAccessory.ps1
@@ -14,6 +14,9 @@ Notes about the accessory
 .PARAMETER qty
 Quantity of the accessory you have
 
+.PARAMETER min_amt
+Minimum amount of the accessory, before alert is triggered
+
 .PARAMETER category_id
 ID number of the category the accessory belongs to
 
@@ -78,11 +81,9 @@ function Set-SnipeitAccessory() {
         [ValidateRange(1, [int]::MaxValue)]
         [int]$category_id,
 
-        [ValidateRange(1, [int]::MaxValue)]
-        [int]$company_id,
+        [Nullable[System.Int32]]$company_id,
 
-        [ValidateRange(1, [int]::MaxValue)]
-        [int]$manufacturer_id,
+        [Nullable[System.Int32]]$manufacturer_id,
 
 
         [string]$order_number,
@@ -91,10 +92,9 @@ function Set-SnipeitAccessory() {
 
         [datetime]$purchase_date,
 
-        [bool]$min_qty,
+        [Nullable[System.Int32]]$min_amt,
 
-        [ValidateRange(1, [int]::MaxValue)]
-        [int]$supplier_id,
+        [Nullable[System.Int32]]$supplier_id,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitAsset.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAsset.ps1
@@ -89,21 +89,23 @@ function Set-SnipeitAsset()
 
         [string]$name,
 
+        [ValidateRange(1, [int]::MaxValue)]
         [int]$status_id,
 
+        [ValidateRange(1, [int]::MaxValue)]
         [int]$model_id,
 
         [DateTime]$last_checkout,
 
-        [int]$assigned_to,
+        [Nullable[System.Int32]]$assigned_to,
 
-        [int]$company_id,
+        [Nullable[System.Int32]]$company_id,
 
         [string]$serial,
 
         [string]$order_number,
 
-        [int]$warranty_months,
+        [Nullable[System.Int32]]$warranty_months,
 
         [double]$purchase_cost,
 
@@ -113,7 +115,7 @@ function Set-SnipeitAsset()
 
         [bool]$archived,
 
-        [int]$rtd_location_id,
+        [Nullable[System.Int32]]$rtd_location_id,
 
         [string]$notes,
 

--- a/SnipeitPS/Public/Set-SnipeitComponent.ps1
+++ b/SnipeitPS/Public/Set-SnipeitComponent.ps1
@@ -58,13 +58,13 @@ function Set-SnipeitComponent()
         [parameter(mandatory = $true)]
         [int]$qty,
 
-        [int]$min_amt,
+        [Nullable[System.Int32]]$min_amt,
 
         [string]$name,
 
-        [int]$company_id,
+        [Nullable[System.Int32]]$company_id,
 
-        [int]$location_id,
+        [Nullable[System.Int32]]$location_id,
 
 
         [string]$order_number,

--- a/SnipeitPS/Public/Set-SnipeitConsumable.ps1
+++ b/SnipeitPS/Public/Set-SnipeitConsumable.ps1
@@ -75,25 +75,27 @@ function Set-SnipeitConsumable()
         [string]$name,
 
         [parameter(mandatory = $false)]
+        [ValidateRange(1, [int]::MaxValue)]
         [int]$qty,
 
         [parameter(mandatory = $false)]
+        [ValidateRange(1, [int]::MaxValue)]
         [int]$category_id,
 
         [parameter(mandatory = $false)]
-        [int]$min_amt,
+        [Nullable[System.Int32]]$min_amt,
 
         [parameter(mandatory = $false)]
-        [int]$company_id,
+        [Nullable[System.Int32]]$company_id,
 
         [parameter(mandatory = $false)]
         [string]$order_number,
 
         [parameter(mandatory = $false)]
-        [int]$manufacturer_id,
+        [Nullable[System.Int32]]$manufacturer_id,
 
         [parameter(mandatory = $false)]
-        [int]$location_id,
+        [Nullable[System.Int32]]$location_id,
 
         [parameter(mandatory = $false)]
         [bool]$requestable,

--- a/SnipeitPS/Public/Set-SnipeitDepartment.ps1
+++ b/SnipeitPS/Public/Set-SnipeitDepartment.ps1
@@ -43,11 +43,11 @@ function Set-SnipeitDepartment() {
 
         [string]$name,
 
-        [int]$company_id,
+        [Nullable[System.Int32]]$company_id,
 
-        [int]$location_id,
+        [Nullable[System.Int32]]$location_id,
 
-        [int]$manager_id,
+        [Nullable[System.Int32]]$manager_id,
 
         [string]$notes,
 

--- a/SnipeitPS/Public/Set-SnipeitLicense.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLicense.ps1
@@ -89,12 +89,11 @@ function Set-SnipeitLicense() {
         [ValidateRange(1, [int]::MaxValue)]
         [int]$category_id,
 
-        [ValidateRange(1, [int]::MaxValue)]
-        [int]$company_id,
+
+        [Nullable[System.Int32]]$company_id,
 
         [datetime]$expiration_date,
 
-        [ValidateLength(1, 120)]
         [mailaddress]$license_email,
 
         [ValidateLength(1, 100)]
@@ -118,8 +117,7 @@ function Set-SnipeitLicense() {
 
         [string]$serial,
 
-        [ValidateRange(1, [int]::MaxValue)]
-        [int]$supplier_id,
+        [Nullable[System.Int32]]$supplier_id,
 
         [datetime]$termination_date,
 

--- a/SnipeitPS/Public/Set-SnipeitLocation.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLocation.ps1
@@ -82,11 +82,11 @@ function Set-SnipeitLocation() {
 
         [string]$currency,
 
-        [int]$manager_id,
+        [Nullable[System.Int32]]$manager_id,
 
         [string]$ldap_ou,
 
-        [int]$parent_id,
+        [Nullable[System.Int32]]$parent_id,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitModel.ps1
+++ b/SnipeitPS/Public/Set-SnipeitModel.ps1
@@ -52,11 +52,10 @@ function Set-SnipeitModel() {
 
         [int]$manufacturer_id,
 
-        [ValidateRange(1, 240)]
-        [int]$eol,
+        [Nullable[System.Int32]]$eol,
 
         [Alias("fieldset_id")]
-        [int]$custom_fieldset_id,
+        [Nullable[System.Int32]]$custom_fieldset_id,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitUser.ps1
+++ b/SnipeitPS/Public/Set-SnipeitUser.ps1
@@ -74,10 +74,12 @@ function Set-SnipeitUser() {
         [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
 
+        [ValidateLength(1,256)]
         [string]$first_name,
 
         [string]$last_name,
 
+        [ValidateLength(1,256)]
         [string]$userName,
 
         [string]$jobtitle,
@@ -86,13 +88,15 @@ function Set-SnipeitUser() {
 
         [string]$phone,
 
-        [int]$company_id,
+        [string]$password,
 
-        [int]$location_id,
+        [Nullable[System.Int32]]$company_id,
 
-        [int]$department_id,
+        [Nullable[System.Int32]]$location_id,
 
-        [int]$manager_id,
+        [Nullable[System.Int32]]$department_id,
+
+        [Nullable[System.Int32]]$manager_id,
 
         [string]$employee_num,
 
@@ -110,6 +114,10 @@ function Set-SnipeitUser() {
         Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+
+        if ($password) {
+            $Values['password_confirmation'] = $password
+        }
 
         $Body = $Values | ConvertTo-Json;
     }

--- a/SnipeitPS/Public/Set-SnipeitUser.ps1
+++ b/SnipeitPS/Public/Set-SnipeitUser.ps1
@@ -20,6 +20,9 @@
     .PARAMETER activated
     Can user log in to snipe-it?
 
+    .PARAMETER password
+    Password for user
+
     .PARAMETER notes
     User Notes
 

--- a/docs/New-SnipeitUser.md
+++ b/docs/New-SnipeitUser.md
@@ -229,7 +229,7 @@ Accept wildcard characters: False
 ```
 
 ### -password
-{{ Fill password Description }}
+Password for user
 
 ```yaml
 Type: String

--- a/docs/Set-SnipeitAccessory.md
+++ b/docs/Set-SnipeitAccessory.md
@@ -15,8 +15,8 @@ Updates accessory on Snipe-It system
 ```
 Set-SnipeitAccessory [-id] <Int32[]> [[-name] <String>] [[-qty] <Int32>] [[-category_id] <Int32>]
  [[-company_id] <Int32>] [[-manufacturer_id] <Int32>] [[-order_number] <String>] [[-purchase_cost] <Single>]
- [[-purchase_date] <DateTime>] [[-min_qty] <Boolean>] [[-supplier_id] <Int32>] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-purchase_date] <DateTime>] [[-min_amt] <Int32>] [[-supplier_id] <Int32>] [-url] <String> [-apiKey] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -71,7 +71,7 @@ Aliases:
 
 Required: False
 Position: 5
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -101,22 +101,22 @@ Aliases:
 
 Required: False
 Position: 6
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -min_qty
-Min quantity of the accessory before alert is triggered
+### -min_amt
+Minimum amount of the accessory, before alert is triggered
 
 ```yaml
-Type: Boolean
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: 10
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -206,7 +206,7 @@ Aliases:
 
 Required: False
 Position: 11
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Set-SnipeitAsset.md
+++ b/docs/Set-SnipeitAsset.md
@@ -84,7 +84,7 @@ Aliases:
 
 Required: False
 Position: 6
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -99,7 +99,7 @@ Aliases:
 
 Required: False
 Position: 7
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -280,7 +280,7 @@ Aliases:
 
 Required: False
 Position: 15
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -340,7 +340,7 @@ Aliases:
 
 Required: False
 Position: 10
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Set-SnipeitComponent.md
+++ b/docs/Set-SnipeitComponent.md
@@ -55,7 +55,7 @@ Aliases:
 
 Required: False
 Position: 5
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -70,7 +70,7 @@ Aliases:
 
 Required: True
 Position: 1
-Default value: 0
+Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
@@ -85,7 +85,7 @@ Aliases:
 
 Required: False
 Position: 6
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -100,7 +100,7 @@ Aliases:
 
 Required: False
 Position: 3
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Set-SnipeitConsumable.md
+++ b/docs/Set-SnipeitConsumable.md
@@ -73,7 +73,7 @@ Aliases:
 
 Required: False
 Position: 6
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -118,7 +118,7 @@ Aliases:
 
 Required: False
 Position: 9
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -133,7 +133,7 @@ Aliases:
 
 Required: False
 Position: 8
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -148,7 +148,7 @@ Aliases:
 
 Required: False
 Position: 5
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Set-SnipeitDepartment.md
+++ b/docs/Set-SnipeitDepartment.md
@@ -55,7 +55,7 @@ Aliases:
 
 Required: False
 Position: 3
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -85,7 +85,7 @@ Aliases:
 
 Required: False
 Position: 4
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -100,7 +100,7 @@ Aliases:
 
 Required: False
 Position: 5
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Set-SnipeitLicense.md
+++ b/docs/Set-SnipeitLicense.md
@@ -73,7 +73,7 @@ Aliases:
 
 Required: False
 Position: 5
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -298,7 +298,7 @@ Aliases:
 
 Required: False
 Position: 17
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Set-SnipeitLicenseSeat.md
+++ b/docs/Set-SnipeitLicenseSeat.md
@@ -61,7 +61,7 @@ Aliases:
 
 Required: False
 Position: 4
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -76,7 +76,7 @@ Aliases: assigned_id
 
 Required: False
 Position: 3
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Set-SnipeitLocation.md
+++ b/docs/Set-SnipeitLocation.md
@@ -161,7 +161,7 @@ Aliases:
 
 Required: False
 Position: 10
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -191,7 +191,7 @@ Aliases:
 
 Required: False
 Position: 12
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Set-SnipeitModel.md
+++ b/docs/Set-SnipeitModel.md
@@ -70,7 +70,7 @@ Aliases: fieldset_id
 
 Required: False
 Position: 7
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -85,7 +85,7 @@ Aliases:
 
 Required: False
 Position: 6
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Set-SnipeitUser.md
+++ b/docs/Set-SnipeitUser.md
@@ -229,7 +229,7 @@ Accept wildcard characters: False
 ```
 
 ### -password
-{{ Fill password Description }}
+Password for user
 
 ```yaml
 Type: String

--- a/docs/Set-SnipeitUser.md
+++ b/docs/Set-SnipeitUser.md
@@ -14,7 +14,7 @@ Creates a new user
 
 ```
 Set-SnipeitUser [-id] <Int32[]> [[-first_name] <String>] [[-last_name] <String>] [[-userName] <String>]
- [[-jobtitle] <String>] [[-email] <String>] [[-phone] <String>] [[-company_id] <Int32>]
+ [[-jobtitle] <String>] [[-email] <String>] [[-phone] <String>] [[-password] <String>] [[-company_id] <Int32>]
  [[-location_id] <Int32>] [[-department_id] <Int32>] [[-manager_id] <Int32>] [[-employee_num] <String>]
  [[-activated] <Boolean>] [[-notes] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
  [<CommonParameters>]
@@ -42,7 +42,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 13
+Position: 14
 Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -57,7 +57,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 16
+Position: 17
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -72,8 +72,8 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
-Default value: 0
+Position: 9
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -87,8 +87,8 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
-Default value: 0
+Position: 11
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -117,7 +117,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 12
+Position: 13
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -192,8 +192,8 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
-Default value: 0
+Position: 10
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -207,8 +207,8 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
-Default value: 0
+Position: 12
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -222,7 +222,22 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 14
+Position: 15
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -password
+{{ Fill password Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -252,7 +267,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 15
+Position: 16
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
As issue #167 shows there's need to clear int values from snipe it. 
Changing parameter type from [int] to [Nullable[System.int32]] will allow this. This PR changes all not required int parameter to nullable version.
