### PR TITLE
Release 1.10

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,6 +6,7 @@
 <!--- Include as many relevant details about the environment you experienced the bug in -->
 * SnipitPS Module version used:
 * Operating System and PowerShell version:
+* Snipe It version:
 
 ## Expected Behavior
 <!--- If you're describing a bug, tell us what should happen -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [v.1.10.x] - 2021-09-03
+
+## New secure ways to connect Snipe it
+
+### -secureApiKey allow pass apiKey as SecureString
+Connect-SnipeitPS -URL 'https://asset.example.com' -secureApiKey 'tokenKey'
+
+### Set connection with safely saved credentials, first save credentials
+$SnipeCred= Get-Credential -message "Use url as username and apikey as password"
+$SnipeCred | Export-CliXml snipecred.xml
+
+### ..then use your saved credentials like
+Connect-SnipeitPS -siteCred (Import-CliXml snipecred.xml)
+
+## Fix for content encoding in invoke-snipeitmethod
+Version 1.9 introduced bug that converted non ascii characters to ascii
+during request.
+
 # [v.1.9.x] - 2021-07-14
 
 ## Image uploads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
+# [v.1.8.x] - 2021-06-17
+
+## Support for new Snipe it endpoints
+
+## New features
+
+Get-SnipeitAccessories -user_id
+returns accessories checked out to user id
+
+Get-SnipeitAsset -user_id
+Return Assets checked out to user id
+
+Get-SnipeitAsset -component_id
+Returns assets with specific component id
+
+Get-SnipeitLicense -user_id
+Get licenses checked out to user ID
+
+Get-SnipeitLicense -asset_id
+Get licenses checked out to asset ID
+
+Get-SnipeitUser -accessory_id
+Get users that have specific accessory id checked out
+
 # [v.1.7.x] - 2021-06-14
 
 ## Consumables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [v.1.9.x] - 2021-07-14
+
+## Image uploads
+
+## New features
+Support for image upload and removes. Just specify filename for -image para-
+meter when creating or updating item on snipe.
+Remove image use -image_delete parameter.
+
+*Snipe It version greater than 5.1.8 is needed to support image parameters.*
+
+Most of set-commands have new -RequestType parameter that defaults to Patch.
+If needed request method can be changed from default.
+
+## New Functions
+Following new commands have been added to SnipeitPS:
+- New-Supplier
+- Set-Supplier
+- Remove-Supplier
+- Set-Manufacturer
+
 
 # [v.1.8.x] - 2021-06-17
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,23 @@ Install-Module SnipeitPS
 # Check for updates occasionally:
 Update-Module SnipeitPS
 
-# To use each session:
+# import module to session:
 Import-Module SnipeitPS
-Set-SnipeitInfo -URL 'https://asset.example.com' -apiKey 'tokenKey'
+
+# Set connection
+Connect-SnipeitPS -URL 'https://asset.example.com' -apiKey 'tokenKey'
+
+# Or set connection with safely saved credentials, first save credentials
+$SnipeCred =Get-Credential -message "Use url as username and apikey as password"
+$SnipeCred | Export-CliXml snipecred.xml
+
+# ..then use your saved credentials like
+Connect-SnipeitPS -siteCred (Import-CliXml snipecred.xml)
+
+# OR use -secureApiKey that allow pass apiKey as SecureString
+# if you are usin Microsoft.PowerShell.SecretManagement or like
+Connect-SnipeitPS -URL 'https://asset.example.com' -secureApiKey 'tokenKey'
+
 ```
 
 ### Usage

--- a/SnipeitPS/Private/Get-ParameterValue.ps1
+++ b/SnipeitPS/Private/Get-ParameterValue.ps1
@@ -57,5 +57,13 @@ function Get-ParameterValue {
         }
         finally {}
     }
+
+    #Convert switch parameters to booleans so it converts nicely to json
+    foreach ( $key in @($ParameterValues.Keys)) {
+      if ($true -eq $ParameterValues[$key].IsPresent){
+        $ParameterValues[$key]=$true;
+      }
+    }
+
     return $ParameterValues
 }

--- a/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
+++ b/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
@@ -1,31 +1,54 @@
-﻿function Invoke-SnipeitMethod {
-    <#
+﻿<#
     .SYNOPSIS
-    Extracted invokation of the REST method to own function.
-    #>
+    Make api request to Snipe it
+
+    .PARAMETER Api
+    Api part of url. prefix with slash ie. "/api/v1/hardware"
+
+    .PARAMETER Method
+    Method of the invokation, one of following "GET", "POST", "PUT", "PATCH" or "DELETE"
+
+    .PARAMETER Body
+    Request body as hashtable. Needed for post, put and patch
+
+    .PARAMETER GetParameters
+    Get-Parameters as hastable.
+#>
+
+function Invoke-SnipeitMethod {
     [OutputType(
         [PSObject]
     )]
-    param (
-        # REST API to invoke
-        [Parameter(Mandatory = $true)]
-        [Uri]$URi,
 
-        # Method of the invokation
+    param (
+
+        [Parameter(Mandatory = $true)]
+        [string]$Api,
+
         [ValidateSet("GET", "POST", "PUT", "PATCH", "DELETE")]
         [string]$Method = "GET",
 
-        # Body of the request
         [Hashtable]$Body,
 
-        [string] $Token,
-
-        # GET Parameters
         [Hashtable]$GetParameters
-
     )
 
     BEGIN {
+        #use legacy per command based url and apikey
+        if ( $null -ne $SnipeitPSSession.legacyUrl -and $null -ne $SnipeitPSSession.legacyApiKey ) {
+            [string]$Url = $SnipeitPSSession.legacyUrl
+            Write-Debug "Invoke-SnipeitMethod url: $Url"
+            $Token =  ConvertFrom-SecureString -AsPlainText -SecureString $SnipeitPSSession.legacyApiKey
+
+        } elseif ($null -ne $SnipeitPSSession.url -and $null -ne $SnipeitPSSession.apiKey) {
+            [string]$Url = $SnipeitPSSession.url
+            Write-Debug "Invoke-SnipeitMethod url: $Url"
+            $Token =  ConvertFrom-SecureString -AsPlainText -SecureString $SnipeitPSSession.apiKey
+
+        } else {
+            throw "Please use Connect-SnipeitPS to setup connection before any other commands."
+        }
+
         # Validation of parameters
         if (($Method -in ("POST", "PUT", "PATCH")) -and (!($Body))) {
             $message = "The following parameters are required when using the ${Method} parameter: Body."
@@ -33,35 +56,36 @@
             Throw $exception
         }
 
+        #Build request uri
+        $apiUri = "$Url$Api"
         #To support images "image" property have be handled before this
 
         $_headers = @{
-            "Authorization" = "Bearer $($token)"
+            "Authorization" = "Bearer $($Token)"
             'Content-Type'  = 'application/json; charset=utf-8'
             "Accept" = "application/json"
         }
     }
 
     Process {
-        if ($GetParameters -and ($URi -notlike "*\?*"))
-        {
+        # This can be done using $Body, maybe some day - PetriAsi
+        if ($GetParameters -and ($apiUri -notlike "*\?*")){
             Write-Debug "Using `$GetParameters: $($GetParameters | Out-String)"
-            [string]$URI += (ConvertTo-GetParameter $GetParameters)
+            [string]$apiUri = $apiUri + (ConvertTo-GetParameter $GetParameters)
             # Prevent recursive appends
             $GetParameters = $null
         }
 
         # set mandatory parameters
         $splatParameters = @{
-            Uri             = $URi
+            Uri             = $apiUri
             Method          = $Method
             Headers         = $_headers
             UseBasicParsing = $true
             ErrorAction     = 'SilentlyContinue'
         }
 
-        # Place holder for intended image manipulation
-        # if and when snipe it API gets support for images
+        # Send image requests as multipart/form-data if supported
         if($null -ne $body -and $Body.Keys -contains 'image' ){
             if($PSVersionTable.PSVersion -ge '7.0'){
                 $Body['image'] = get-item $body['image']
@@ -71,10 +95,10 @@
                 $splatParameters["Method"] = 'POST'
                 $splatParameters["Form"] = $Body
             } else {
-                    # use base64 encoded images for powershell  version < 7
-                    Add-Type -AssemblyName "System.Web"
-                    $mimetype = [System.Web.MimeMapping]::GetMimeMapping($body['image'])
-                    $Body['image'] = 'data:@'+$mimetype+';base64,'+[Convert]::ToBase64String([IO.File]::ReadAllBytes($Body['image']))
+                # use base64 encoded images for powershell  version < 7
+                Add-Type -AssemblyName "System.Web"
+                $mimetype = [System.Web.MimeMapping]::GetMimeMapping($body['image'])
+                $Body['image'] = 'data:@'+$mimetype+';base64,'+[Convert]::ToBase64String([IO.File]::ReadAllBytes($Body['image']))
             }
         }
 
@@ -105,18 +129,16 @@
             if ($webResponse) {
                  Write-Verbose $webResponse
 
-                # API returned a Content: lets work wit it
+                # API returned a Content: lets work with it
                 try{
-
                     if ($webResponse.status -eq "error") {
-                        Write-Verbose "[$($MyInvocation.MyCommand.Name)] An error response was received from; resolving"
+                        Write-Verbose "[$($MyInvocation.MyCommand.Name)] An error response was received ... resolving"
                         # This could be handled nicely in an function such as:
                         # ResolveError $response -WriteError
                         Write-Error $($webResponse.messages | Out-String)
-                    }
-                    else {
+                    } else {
                         #update operations return payload
-                        if ($webResponse.payload){
+                        if ($webResponse.payload) {
                             $result = $webResponse.payload
                         }
                         #Search operations return rows
@@ -124,7 +146,7 @@
                             $result = $webResponse.rows
                         }
                         #Remove operations returns status and message
-                        elseif ($webResponse.status -eq 'success'){
+                        elseif ($webResponse.status -eq 'success') {
                             $result = $webResponse.payload
                         }
                         #Search and query result with no results
@@ -140,9 +162,6 @@
                         Write-Verbose "Messages: $($webResponse.messages)"
 
                         $result
-
-
-
                     }
                 }
                 catch {
@@ -151,7 +170,7 @@
 
             }
             elseif ($webResponse.StatusCode -eq "Unauthorized") {
-                Write-Error "[$($MyInvocation.MyCommand.Name)] You are not Authorized to access the resource, check your token is correct"
+                Write-Error "[$($MyInvocation.MyCommand.Name)] You are not Authorized to access the resource, check your apiKey is correct"
             }
             else {
                 # No content, although statusCode < 400
@@ -169,3 +188,4 @@
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function ended"
     }
 }
+

--- a/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
+++ b/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
@@ -103,7 +103,7 @@ function Invoke-SnipeitMethod {
         }
 
         if ($Body -and $splatParameters.Keys -notcontains 'Form') {
-            $splatParameters["Body"] = $Body | Convertto-Json
+            $splatParameters["Body"] =  [System.Text.Encoding]::UTF8.GetBytes(($Body | Convertto-Json))
         }
 
         $script:PSDefaultParameterValues = $global:PSDefaultParameterValues

--- a/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
+++ b/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
@@ -64,12 +64,14 @@
         #Place holder for intended image manipulation
         # if and when snipe it API gets support for images
         if($null -ne $body -and $Body.Keys -contains 'image' ){
-            if($PSVersionTable.PSVersion -ge 7){
+            if($PSVersionTable.PSVersion -ge '7.0'){
                 $Body['image'] = get-item $body['image']
                 $splatParameters["Form"] = $Body
             } else {
-                    write-warning "Setting images is supported only with powershell version 7 or greater"
-                    $Body.Remove('image')
+                    # use base64 encoded images for powershell  version < 7
+                    Add-Type -AssemblyName "System.Web"
+                    $mimetype = [System.Web.MimeMapping]::GetMimeMapping($body['image'])
+                    $Body['image'] = 'data:@'+$mimetype+';base64,'+[Convert]::ToBase64String([IO.File]::ReadAllBytes($Body['image']))
             }
         }
 

--- a/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
+++ b/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
@@ -127,6 +127,10 @@
                         elseif ($webResponse.status -eq 'success'){
                             $result = $webResponse.payload
                         }
+                        #Search and query result with no results
+                        elseif ($webResponse.total -eq 0){
+                            $result = $null
+                        }
                         #get operations with id returns just one object
                         else {
                             $result = $webResponse

--- a/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
+++ b/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
@@ -17,7 +17,7 @@
 
         # Body of the request
         [ValidateNotNullOrEmpty()]
-        [string]$Body,
+        [Hashtable]$Body,
 
         [string] $Token,
 
@@ -33,6 +33,8 @@
             $exception = New-Object -TypeName System.ArgumentException -ArgumentList $message
             Throw $exception
         }
+
+        #To support images "image" property have be handled before this
 
         $_headers = @{
             "Authorization" = "Bearer $($token)"
@@ -57,19 +59,34 @@
             Headers         = $_headers
             UseBasicParsing = $true
             ErrorAction     = 'SilentlyContinue'
+            Proxy           = 'http://localhost:8080'
         }
 
-        if ($Body) {$splatParameters["Body"] = [System.Text.Encoding]::UTF8.GetBytes($Body)}
+        #Place holder for intended image manipulation
+        # if and when snipe it API gets support for images
+        if($null -ne $body -and $Body.Keys -contains 'image' ){
+            if($PSVersionTable.PSVersion -ge 7){
+                $Body['image'] = get-item $body['image']
+                $splatParameters["Form"] = $Body
+            } else {
+                    write-warning "Setting images is supported only with powershell version 7 or greater"
+                    $Body.Remove('image')
+            }
+        }
+
+        if ($Body -and $splatParameters.Keys -notcontains 'Form') {
+            $splatParameters["Body"] = $Body | Convertto-Json
+        }
 
         $script:PSDefaultParameterValues = $global:PSDefaultParameterValues
 
-        Write-Debug $Body
+        Write-Debug "$($Body | ConvertTo-Json)"
 
         # Invoke the API
         try {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Invoking method $Method to URI $URi"
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoke-WebRequest with: $($splatParameters | Out-String)"
-            $webResponse = Invoke-WebRequest @splatParameters
+            $webResponse = Invoke-RestMethod @splatParameters
         }
         catch {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Failed to get an answer from the server"
@@ -81,30 +98,43 @@
         if ($webResponse) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Status code: $($webResponse.StatusCode)"
 
-            if ($webResponse.Content) {
-                 Write-Verbose $webResponse.Content
+            if ($webResponse) {
+                 Write-Verbose $webResponse
 
                 # API returned a Content: lets work wit it
                 try{
-                    $response = ConvertFrom-Json -InputObject $webResponse.Content
 
-                    if ($response.status -eq "error") {
+                    if ($webResponse.status -eq "error") {
                         Write-Verbose "[$($MyInvocation.MyCommand.Name)] An error response was received from; resolving"
                         # This could be handled nicely in an function such as:
                         # ResolveError $response -WriteError
-                        Write-Error $($response.messages | Out-String)
+                        Write-Error $($webResponse.messages | Out-String)
                     }
                     else {
-                        $result = $response
-                        if (($response) -and ($response | Get-Member -Name payload))
-                        {
-                            $result = $response.payload
+                        #update operations return payload
+                        if ($webResponse.payload){
+                            $result = $webResponse.payload
                         }
-                        elseif (($response) -and ($response | Get-Member -Name rows)) {
-                            $result = $response.rows
+                        #Search operations return rows
+                        elseif ($webResponse.rows) {
+                            $result = $webResponse.rows
+                        }
+                        #Remove operations returns status and message
+                        elseif ($webResponse.status -eq 'success'){
+                            $result = $webResponse.payload
+                        }
+                        #get operations with id returns just one object
+                        else {
+                            $result = $webResponse
                         }
 
+                        Write-Verbose "Status: $($webResponse.status)"
+                        Write-Verbose "Messages: $($webResponse.messages)"
+
                         $result
+
+
+
                     }
                 }
                 catch {

--- a/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
+++ b/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
@@ -59,7 +59,6 @@
             Headers         = $_headers
             UseBasicParsing = $true
             ErrorAction     = 'SilentlyContinue'
-            Proxy           = 'http://localhost:8080'
         }
 
         #Place holder for intended image manipulation

--- a/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
+++ b/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
@@ -61,11 +61,15 @@
             ErrorAction     = 'SilentlyContinue'
         }
 
-        #Place holder for intended image manipulation
+        # Place holder for intended image manipulation
         # if and when snipe it API gets support for images
         if($null -ne $body -and $Body.Keys -contains 'image' ){
             if($PSVersionTable.PSVersion -ge '7.0'){
                 $Body['image'] = get-item $body['image']
+                # As multipart/form-data is always POST we need add
+                # requested method for laravel named as '_method'
+                $Body['_method'] = $Method
+                $splatParameters["Method"] = 'POST'
                 $splatParameters["Form"] = $Body
             } else {
                     # use base64 encoded images for powershell  version < 7

--- a/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
+++ b/SnipeitPS/Private/Invoke-SnipeitMethod.ps1
@@ -16,7 +16,6 @@
         [string]$Method = "GET",
 
         # Body of the request
-        [ValidateNotNullOrEmpty()]
         [Hashtable]$Body,
 
         [string] $Token,

--- a/SnipeitPS/Private/Reset-SnipeitPSLegacyApi.ps1
+++ b/SnipeitPS/Private/Reset-SnipeitPSLegacyApi.ps1
@@ -1,0 +1,16 @@
+function Reset-SnipeitPSLegacyApi {
+    [CmdletBinding(
+        SupportsShouldProcess = $true,
+        ConfirmImpact = "Low"
+    )]
+    param(
+    )
+    process {
+        Write-Verbose 'Reset-SnipeitPSLegacyApi'
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            $SnipeitPSSession.legacyUrl = $null
+            $SnipeitPSSession.legacyApiKey = $null
+
+        }
+    }
+}

--- a/SnipeitPS/Private/Set-SnipeitPSLegacyApiKey.ps1
+++ b/SnipeitPS/Private/Set-SnipeitPSLegacyApiKey.ps1
@@ -1,0 +1,14 @@
+function Set-SnipeitPSLegacyApiKey {
+    [CmdletBinding(
+        SupportsShouldProcess = $true,
+        ConfirmImpact = "Low"
+    )]
+    param(
+        [string]$apiKey
+    )
+    process {
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            $SnipeitPSSession.legacyApiKey = ConvertTo-SecureString -AsPlainText -String $apiKey
+        }
+    }
+}

--- a/SnipeitPS/Private/Set-SnipeitPSLegacyUrl.ps1
+++ b/SnipeitPS/Private/Set-SnipeitPSLegacyUrl.ps1
@@ -1,0 +1,14 @@
+function Set-SnipeitPSLegacyUrl {
+    [CmdletBinding(
+        SupportsShouldProcess = $true,
+        ConfirmImpact = "Low"
+    )]
+    param(
+        $url
+    )
+    process {
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            $SnipeitPSSession.legacyUrl = $url.TrimEnd('/')
+        }
+    }
+}

--- a/SnipeitPS/Private/Test-SnipeitPSConnection.ps1
+++ b/SnipeitPS/Private/Test-SnipeitPSConnection.ps1
@@ -1,0 +1,18 @@
+function Test-SnipeitPSConnection {
+    #test api connection
+    $Parameters = @{
+        Api           = '/api/v1/statuslabels'
+        Method        = 'Get'
+        GetParameters = @{'limit'=1}
+    }
+    Write-Verbose "Testing connection to $($SnipeitPSSession.url)."
+
+    $contest = Invoke-SnipeitMethod @Parameters
+
+    if ( $contest) {
+        Write-Verbose "Connection to $($SnipeitPSSession.url) tested succesfully."
+        return $true
+    } else {
+        return $false
+    }
+}

--- a/SnipeitPS/Public/Connect-SnipeitPS.ps1
+++ b/SnipeitPS/Public/Connect-SnipeitPS.ps1
@@ -1,0 +1,93 @@
+<#
+    .SYNOPSIS
+    Sets authetication information
+
+    .DESCRIPTION
+    Sets apikey and url to connect Snipe-It system.
+    Based on Set-SnipeitInfo command, what is now just compatibility wrapper
+    and calls Connect-SnipeitPS
+
+    .PARAMETER url
+    URL of Snipeit system.
+
+    .PARAMETER apiKey
+    User's API Key for Snipeit.
+
+    .PARAMETER secureApiKey
+    Snipe it Api key as securestring
+
+    .PARAMETER siteCred
+    PSCredential where username shoul be snipe it url and password should be
+    snipe it apikey.
+
+    .EXAMPLE
+    Connect-SnipeitPS -Url $url -apiKey $myapikey
+    Connect to  Snipe it  api.
+
+    .EXAMPLE
+    Connect-SnipeitPS -Url $url -SecureApiKey $myapikey
+    Connects to Snipe it api with apikey stored to securestring
+
+    .EXAMPLE
+    Connect-SnipeitPS -siteCred (Get-Credential -message "Use site url as username and apikey as password")
+    Connect to Snipe It with PSCredential object.
+    To use saved creadentials yu can use export-clixml and import-clixml commandlets.
+
+    .EXAMPLE
+    Build credential with apikey value from secret vault (Microsoft.PowerShell.SecretManagement)
+    $siteurl = "https://mysnipeitsite.url"
+    $apikey = Get-SecretInfo -Name SnipeItApiKey
+    $siteCred = New-Object -Type PSCredential -Argumentlist $siteurl,$spikey
+    Connect-SnipeitPS -siteCred $siteCred
+
+
+
+#>
+function Connect-SnipeitPS {
+    [CmdletBinding(
+        DefaultParameterSetName = 'Connect with url and apikey'
+    )]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseShouldProcessForStateChangingFunctions', '')]
+
+    param (
+        [Parameter(ParameterSetName='Connect with url and apikey',Mandatory=$true)]
+        [Parameter(ParameterSetName='Connect with url and secure apikey',Mandatory=$true)]
+        [Uri]$url,
+
+        [Parameter(ParameterSetName='Connect with url and apikey',Mandatory=$true)]
+        [String]$apiKey,
+
+        [Parameter(ParameterSetName='Connect with url and secure apikey',Mandatory=$true)]
+        [SecureString]$secureApiKey,
+
+        [Parameter(ParameterSetName='Connect with credential',Mandatory=$true)]
+        [PSCredential]$siteCred
+    )
+
+
+    PROCESS {
+        switch ($PsCmdlet.ParameterSetName) {
+            'Connect with url and apikey' {
+                $SnipeitPSSession.url = $url.AbsoluteUri.TrimEnd('/')
+                $SnipeitPSSession.apiKey = ConvertTo-SecureString -AsPlainText -String $apiKey
+            }
+
+            'Connect with url and secure apikey' {
+                $SnipeitPSSession.url = $url.AbsoluteUri.TrimEnd('/')
+                $SnipeitPSSession.apiKey = $secureApiKey
+            }
+
+            'Connect with credential' {
+                $SnipeitPSSession.url = ($siteCred.GetNetworkCredential().UserName).TrimEnd('/')
+                $SnipeitPSSession.apiKey = $siteCred.GetNetworkCredential().SecurePassword
+            }
+        }
+
+        Write-Debug "Site-url $($SnipeitPSSession.url)"
+        Write-Debug "Site apikey: $($SnipeitPSSession.apiKey)"
+
+        if (-not (Test-SnipeitPSConnection)) {
+            throw "Cannot verify connection to snipe it. For the start try to check url and provided apikey or credential parameters"
+        }
+    }
+}

--- a/SnipeitPS/Public/Get-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/Get-SnipeitAccessory.ps1
@@ -32,6 +32,10 @@ Get-SnipeitAccessory -search Keyboard
 .EXAMPLE
 Get-SnipeitAccessory -id 1
 
+.EXAMPLE
+Get-SnipeitAccessory -user_id 1
+Get accessories checked out to user ID 1
+
 #>
 
 function Get-SnipeitAccessory() {
@@ -42,6 +46,9 @@ function Get-SnipeitAccessory() {
 
         [parameter(ParameterSetName='Get by ID')]
         [int]$id,
+
+        [parameter(ParameterSetName='Accessories checked out to user id')]
+        [int]$user_id,
 
         [parameter(ParameterSetName='Search')]
         [int]$company_id,
@@ -69,6 +76,7 @@ function Get-SnipeitAccessory() {
         [int]$offset,
 
         [parameter(ParameterSetName='Search')]
+        [parameter(ParameterSetName='Accessories checked out to user id')]
         [switch]$all = $false,
 
         [parameter(mandatory = $true)]
@@ -79,21 +87,19 @@ function Get-SnipeitAccessory() {
     )
     Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    if ($id -and $search){
-        throw "Please specify only one of -id or -search parameter"
+    switch($PsCmdlet.ParameterSetName) {
+        'Search' {$apiurl = "$url/api/v1/accessories"}
+        'Get by ID' {$apiurl= "$url/api/v1/accessories/$id"}
+        'Accessories checked out to user id' {$apiurl = "$url/api/v1/users/$user_id/accessories"}
     }
 
     $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
     $Parameters = @{
-        Uri           = "$url/api/v1/accessories"
+        Uri           = $apiurl
         Method        = 'Get'
         GetParameters = $SearchParameter
         Token         = $apiKey
-    }
-
-    if($id){
-        $Parameters.Uri ="$url/api/v1/accessories/$id"
     }
 
     if ($all) {

--- a/SnipeitPS/Public/Get-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/Get-SnipeitAccessory.ps1
@@ -21,10 +21,10 @@ Result offset to use
 A return all results, works with -offset and other parameters
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
 .EXAMPLE
 Get-SnipeitAccessory -search Keyboard
@@ -79,47 +79,67 @@ function Get-SnipeitAccessory() {
         [parameter(ParameterSetName='Accessories checked out to user id')]
         [switch]$all = $false,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    switch($PsCmdlet.ParameterSetName) {
-        'Search' {$apiurl = "$url/api/v1/accessories"}
-        'Get by ID' {$apiurl= "$url/api/v1/accessories/$id"}
-        'Accessories checked out to user id' {$apiurl = "$url/api/v1/users/$user_id/accessories"}
-    }
-
-    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-    $Parameters = @{
-        Uri           = $apiurl
-        Method        = 'Get'
-        GetParameters = $SearchParameter
-        Token         = $apiKey
-    }
-
-    if ($all) {
-        $offstart = $(if($offset){$offset} Else {0})
-        $callargs = $SearchParameter
-        $callargs.Remove('all')
-
-        while ($true) {
-            $callargs['offset'] = $offstart
-            $callargs['limit'] = $limit
-            $res=Get-SnipeitAccessory @callargs
-            $res
-            if ($res.count -lt $limit) {
-                break
-            }
-            $offstart = $offstart + $limit
+        switch($PsCmdlet.ParameterSetName) {
+            'Search' {$api = "/api/v1/accessories"}
+            'Get by ID' {$api= "/api/v1/accessories/$id"}
+            'Accessories checked out to user id' {$api = "/api/v1/users/$user_id/accessories"}
         }
-    } else {
-        $result = Invoke-SnipeitMethod @Parameters
-        $result
+
+        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+
+        $Parameters = @{
+            Api           = $api
+            Method        = 'Get'
+            GetParameters = $SearchParameter
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+    }
+
+    process {
+        if ($all) {
+            $offstart = $(if ($offset) {$offset} Else {0})
+            $callargs = $SearchParameter
+            $callargs.Remove('all')
+
+            while ($true) {
+                $callargs['offset'] = $offstart
+                $callargs['limit'] = $limit
+                $res=Get-SnipeitAccessory @callargs
+                $res
+                if ($res.count -lt $limit) {
+                    break
+                }
+                $offstart = $offstart + $limit
+            }
+        } else {
+            $result = Invoke-SnipeitMethod @Parameters
+            $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }
 

--- a/SnipeitPS/Public/Get-SnipeitAccessoryOwner.ps1
+++ b/SnipeitPS/Public/Get-SnipeitAccessoryOwner.ps1
@@ -8,16 +8,15 @@
     Unique ID For accessory to list
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
     Get-SnipeitAccessoryOwner -id 1
 #>
-function Get-SnipeitAccessoryOwner()
-{
+function Get-SnipeitAccessoryOwner() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Medium"
@@ -27,23 +26,39 @@ function Get-SnipeitAccessoryOwner()
         [parameter(mandatory = $true)]
         [int]$id,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
+    begin {
+        $Parameters = @{
+            Api    = "/api/v1/accessories/$id/checkedout"
+            Method = 'GET'
+        }
 
-    $Parameters = @{
-        Uri    = "$url/api/v1/accessories/$id/checkedout"
-        Method = 'GET'
-        Token  = $apiKey
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+    }
+    process {
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            $result = Invoke-SnipeitMethod @Parameters
+        }
+        $result
     }
 
-    If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-    {
-        $result = Invoke-SnipeitMethod @Parameters
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
-
-    return $result
 }

--- a/SnipeitPS/Public/Get-SnipeitActivity.ps1
+++ b/SnipeitPS/Public/Get-SnipeitActivity.ps1
@@ -30,10 +30,10 @@ Result offset to use
 A return all results, works with -offset and other parameters
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
 .EXAMPLE
 Get-SnipeitAccessory -search Keyboard
@@ -71,51 +71,70 @@ function Get-SnipeitActivity() {
 
         [switch]$all = $false,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
-
-    if(($target_type -and -not $target_id) -or
-        ($target_id -and -not $target_type)) {
-        throw "Please specify both target_type and target_id"
-    }
-
-    if(($item_type -and -not $item_id) -or
-        ($item_id -and -not $item_type)) {
-        throw "Please specify both item_type and item_id"
-    }
-
-    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-
-    $Parameters = @{
-        Uri           = "$url/api/v1/reports/activity"
-        Method        = 'Get'
-        GetParameters = $SearchParameter
-        Token         = $apiKey
-    }
-
-    if ($all) {
-        $offstart = $(if($offset){$offset} Else {0})
-        $callargs = $SearchParameter
-        $callargs.Remove('all')
-
-        while ($true) {
-            $callargs['offset'] = $offstart
-            $callargs['limit'] = $limit
-            $res=Get-SnipeitActivity @callargs
-            $res
-            if ($res.count -lt $limit) {
-                break
-            }
-            $offstart = $offstart + $limit
+    begin {
+        if (($target_type -and -not $target_id) -or
+            ($target_id -and -not $target_type)) {
+            throw "Please specify both target_type and target_id"
         }
-    } else {
-        $result = Invoke-SnipeitMethod @Parameters
-        $result
+
+        if (($item_type -and -not $item_id) -or
+            ($item_id -and -not $item_type)) {
+            throw "Please specify both item_type and item_id"
+        }
+
+        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+
+
+        $Parameters = @{
+            Api           = "/api/v1/reports/activity"
+            Method        = 'Get'
+            GetParameters = $SearchParameter
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+    }
+
+    process {
+        if ($all) {
+            $offstart = $(if ($offset) {$offset} Else {0})
+            $callargs = $SearchParameter
+            $callargs.Remove('all')
+
+            while ($true) {
+                $callargs['offset'] = $offstart
+                $callargs['limit'] = $limit
+                $res=Get-SnipeitActivity @callargs
+                $res
+                if ($res.count -lt $limit) {
+                    break
+                }
+                $offstart = $offstart + $limit
+            }
+        } else {
+            $result = Invoke-SnipeitMethod @Parameters
+            $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }
 

--- a/SnipeitPS/Public/Get-SnipeitAsset.ps1
+++ b/SnipeitPS/Public/Get-SnipeitAsset.ps1
@@ -66,16 +66,42 @@ URL of Snipeit system, can be set using Set-SnipeitInfo command
 Users API Key for Snipeit, can be set using Set-SnipeitInfo command
 
 .EXAMPLE
-Get-SnipeitAsset -url "https://assets.example.com"-token "token..."
+Get-SnipeitAsset -all -url "https://assets.example.com"-token "token..."
+Returens all assets
 
 .EXAMPLE
-Get-SnipeitAsset -search "myMachine"-url "https://assets.example.com"-token "token..."
+Get-SnipeitAsset -search "myMachine"
+Search for specific asset
 
 .EXAMPLE
-Get-SnipeitAsset -search "myMachine"-url "https://assets.example.com"-token "token..."
+Get-SnipeitAsset -id 3
+Get asset with id number 3
 
 .EXAMPLE
-Get-SnipeitAsset -asset_tag "myAssetTag"-url "https://assets.example.com"-token "token..."
+Get-SnipeitAsset -asset_tag snipe0003
+Get asset with asset tag snipe00033
+
+.EXAMPLE
+Get-SnipeitAsset -serial 1234
+Get asset with searial number 1234
+
+.EXAMPLE
+Get-SnipeitAsser -audit_due
+Get Assets due auditing soon
+
+.EXAMPLE
+Get-SnipeitAsser -audit_overdue
+Get Assets overdue for auditing
+
+.EXAMPLE
+Get-AnipeitAsset -user_id 4
+Get Assets checked out to user id 4
+
+.EXAMPLE
+Get-SnipeitAsset -component_id 5
+Get Assets with component id 5
+
+
 #>
 
 function Get-SnipeitAsset() {
@@ -99,6 +125,12 @@ function Get-SnipeitAsset() {
 
         [parameter(ParameterSetName='Assets overdue for auditing')]
         [switch]$audit_overdue,
+
+        [parameter(ParameterSetName='Assets checked out to user id')]
+        [int]$user_id,
+
+        [parameter(ParameterSetName='Assets with component id')]
+        [int]$component_id,
 
         [parameter(ParameterSetName='Search')]
         [string]$order_number,
@@ -133,28 +165,38 @@ function Get-SnipeitAsset() {
         [parameter(ParameterSetName='Search')]
         [parameter(ParameterSetName='Assets due auditing soon')]
         [parameter(ParameterSetName='Assets overdue for auditing')]
+        [parameter(ParameterSetName='Assets checked out to user id')]
+        [parameter(ParameterSetName='Assets with component id')]
         [ValidateSet('id','created_at','asset_tag','serial','order_number','model_id','category_id','manufacturer_id','company_id','location_id','status','status_id')]
         [string]$sort,
 
         [parameter(ParameterSetName='Search')]
         [parameter(ParameterSetName='Assets due auditing soon')]
         [parameter(ParameterSetName='Assets overdue for auditing')]
+        [parameter(ParameterSetName='Assets checked out to user id')]
+        [parameter(ParameterSetName='Assets with component id')]
         [ValidateSet("asc", "desc")]
         [string]$order,
 
         [parameter(ParameterSetName='Search')]
         [parameter(ParameterSetName='Assets due auditing soon')]
         [parameter(ParameterSetName='Assets overdue for auditing')]
+        [parameter(ParameterSetName='Assets checked out to user id')]
+        [parameter(ParameterSetName='Assets with component id')]
         [int]$limit = 50,
 
         [parameter(ParameterSetName='Search')]
         [parameter(ParameterSetName='Assets due auditing soon')]
         [parameter(ParameterSetName='Assets overdue for auditing')]
+        [parameter(ParameterSetName='Assets checked out to user id')]
+        [parameter(ParameterSetName='Assets with component id')]
         [int]$offset,
 
         [parameter(ParameterSetName='Search')]
         [parameter(ParameterSetName='Assets due auditing soon')]
         [parameter(ParameterSetName='Assets overdue for auditing')]
+        [parameter(ParameterSetName='Assets checked out to user id')]
+        [parameter(ParameterSetName='Assets with component id')]
         [switch]$all = $false,
 
         [parameter(mandatory = $true)]
@@ -175,6 +217,8 @@ function Get-SnipeitAsset() {
         'Get with serial' { $apiurl= "$url/api/v1/hardware/byserial/$serial"}
         'Assets due auditing soon' {$apiurl = "$url/api/v1/hardware/audit/due"}
         'Assets overdue for auditing' {$apiurl = "$url/api/v1/hardware/audit/overdue"}
+        'Assets checked out to user id'{$apiurl = "$url/api/v1/users/$user_id/assets"}
+        'Assets with component id' {$apiurl = "$url/api/v1/components/$component_id/assets"}
     }
 
 

--- a/SnipeitPS/Public/Get-SnipeitAsset.ps1
+++ b/SnipeitPS/Public/Get-SnipeitAsset.ps1
@@ -221,7 +221,6 @@ function Get-SnipeitAsset() {
         'Assets with component id' {$apiurl = "$url/api/v1/components/$component_id/assets"}
     }
 
-
     $Parameters = @{
         Uri           = $apiurl
         Method        = 'Get'

--- a/SnipeitPS/Public/Get-SnipeitCompany.ps1
+++ b/SnipeitPS/Public/Get-SnipeitCompany.ps1
@@ -17,10 +17,10 @@ Offset to use
 .PARAMETER all
 A return all results, works with -offset and other parameters
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
 .EXAMPLE
 Get-SnipeitCompany
@@ -32,8 +32,7 @@ Gets specific company
 
 #>
 
-function Get-SnipeitCompany()
-{
+function Get-SnipeitCompany() {
     [CmdletBinding(DefaultParameterSetName = 'Search')]
     Param(
         [parameter(ParameterSetName='Search')]
@@ -55,51 +54,70 @@ function Get-SnipeitCompany()
         [parameter(ParameterSetName='Search')]
         [switch]$all = $false,
 
-        [parameter(mandatory=$true)]
+        [parameter(mandatory=$false)]
         [string]$url,
 
-        [parameter(mandatory=$true)]
+        [parameter(mandatory=$false)]
         [string]$apiKey
     )
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $apiurl = "$url/api/v1/companies"
+        $api = "/api/v1/companies"
 
-    if ($search -and $id ) {
-         Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
-    }
-
-    if ($id) {
-       $apiurl= "$url/api/v1/companies/$id"
-    }
-
-    $Parameters = @{
-        Uri           = $apiurl
-        Method        = 'Get'
-        Token         = $apiKey
-        GetParameters = $SearchParameter
-    }
-
-    if ($all) {
-        $offstart = $(if($offset){$offset} Else {0})
-        $callargs = $SearchParameter
-        $callargs.Remove('all')
-
-        while ($true) {
-            $callargs['offset'] = $offstart
-            $callargs['limit'] = $limit
-            $res=Get-SnipeitCompany @callargs
-            $res
-            if ($res.count -lt $limit) {
-                break
-            }
-            $offstart = $offstart + $limit
+        if ($search -and $id ) {
+            Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
         }
-    } else {
-        $result = Invoke-SnipeitMethod @Parameters
-        $result
+
+        if ($id) {
+        $api= "/api/v1/companies/$id"
+        }
+
+        $Parameters = @{
+            Api           = $api
+            Method        = 'Get'
+            GetParameters = $SearchParameter
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+    }
+    process {
+        if ($all) {
+            $offstart = $(if ($offset) {$offset} Else {0})
+            $callargs = $SearchParameter
+            $callargs.Remove('all')
+
+            while ($true) {
+                $callargs['offset'] = $offstart
+                $callargs['limit'] = $limit
+                $res=Get-SnipeitCompany @callargs
+                $res
+                if ($res.count -lt $limit) {
+                    break
+                }
+                $offstart = $offstart + $limit
+            }
+        } else {
+            $result = Invoke-SnipeitMethod @Parameters
+            $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }

--- a/SnipeitPS/Public/Get-SnipeitComponent.ps1
+++ b/SnipeitPS/Public/Get-SnipeitComponent.ps1
@@ -18,10 +18,10 @@ Offset to use
 A return all results, works with -offset and other parameters
 
 .PARAMETER url
-URL of Snipeit system,can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
 .EXAMPLE
 Get-SnipeitComponent
@@ -71,51 +71,71 @@ function Get-SnipeitComponent() {
         [parameter(ParameterSetName='Search')]
         [switch]$all = $false,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $apiurl = "$url/api/v1/components"
+        $api = "/api/v1/components"
 
-    if ($search -and $id ) {
-         Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
-    }
-
-    if ($id) {
-       $apiurl= "$url/api/v1/components/$id"
-    }
-
-    $Parameters = @{
-        Uri           = $apiurl
-        Method        = 'Get'
-        Token         = $apiKey
-        GetParameters = $SearchParameter
-    }
-
-    if ($all) {
-        $offstart = $(if($offset){$offset} Else {0})
-        $callargs = $SearchParameter
-        $callargs.Remove('all')
-
-        while ($true) {
-            $callargs['offset'] = $offstart
-            $callargs['limit'] = $limit
-            $res=Get-SnipeitComponent @callargs
-            $res
-            if ($res.count -lt $limit) {
-                break
-            }
-            $offstart = $offstart + $limit
+        if ($search -and $id ) {
+            Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
         }
-    } else {
-        $result = Invoke-SnipeitMethod @Parameters
-        $result
+
+        if ($id) {
+        $api= "/api/v1/components/$id"
+        }
+
+        $Parameters = @{
+            Api           = $api
+            Method        = 'Get'
+            GetParameters = $SearchParameter
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+    }
+
+    process {
+        if ($all) {
+            $offstart = $(if ($offset) {$offset} Else {0})
+            $callargs = $SearchParameter
+            $callargs.Remove('all')
+
+            while ($true) {
+                $callargs['offset'] = $offstart
+                $callargs['limit'] = $limit
+                $res=Get-SnipeitComponent @callargs
+                $res
+                if ($res.count -lt $limit) {
+                    break
+                }
+                $offstart = $offstart + $limit
+            }
+        } else {
+            $result = Invoke-SnipeitMethod @Parameters
+            $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }

--- a/SnipeitPS/Public/Get-SnipeitCustomField.ps1
+++ b/SnipeitPS/Public/Get-SnipeitCustomField.ps1
@@ -6,44 +6,67 @@
     A id of specific field
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
-    Get-SnipeitCustomField -url "https://assets.example.com" -token "token..."
+    Get-SnipeitCustomField
+    Get all custom fields
+
+    .EXAMPLE
+    Get-SnipeitCustomField -id 1
+    Get custom field with ID 1
+
 
 #>
 
-function Get-SnipeitCustomField()
-{
+function Get-SnipeitCustomField() {
     Param(
         [int]$id,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    if ($id) {
-        $apiurl= "$url/api/v1/fields/$id"
-    } else {
-        $apiurl = "$url/api/v1/fields"
+        if ($id) {
+            $api= "/api/v1/fields/$id"
+        } else {
+            $api = "/api/v1/fields"
+        }
+
+        $Parameters = @{
+            Api           = $api
+            Method        = 'Get'
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
     }
 
-    $Parameters = @{
-        Uri           = $apiurl
-        Method        = 'Get'
-        Token         = $apiKey
+    process {
+        $result = Invoke-SnipeitMethod @Parameters
+        $result
     }
 
-
-    $result = Invoke-SnipeitMethod @Parameters
-
-    $result
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
+    }
 }

--- a/SnipeitPS/Public/Get-SnipeitDepartment.ps1
+++ b/SnipeitPS/Public/Get-SnipeitDepartment.ps1
@@ -18,13 +18,13 @@ Offset to use
 A return all results, works with -offset and other parameters
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
 .EXAMPLE
-Get-SnipeitDepartment -url "https://assets.example.com" -token "token..."
+Get-SnipeitDepartment
 
 .EXAMPLE
 Get-SnipeitDepartment -search  Department1
@@ -34,8 +34,7 @@ Get-SnipeitDepartment -id 1
 
 #>
 
-function Get-SnipeitDepartment()
-{
+function Get-SnipeitDepartment() {
     [CmdletBinding(DefaultParameterSetName = 'Search')]
     Param(
         [parameter(ParameterSetName='Search')]
@@ -61,52 +60,71 @@ function Get-SnipeitDepartment()
         [ValidateSet('id', 'name', 'image', 'users_count', 'created_at')]
         [string]$sort = "created_at",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
+    begin {
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $apiurl = "$url/api/v1/departments"
+        $api = "/api/v1/departments"
 
-    if ($search -and $id ) {
-         Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
-    }
-
-    if ($id) {
-       $apiurl= "$url/api/v1/departments/$id"
-    }
-
-    $Parameters = @{
-        Uri           = $apiurl
-        Method        = 'Get'
-        Token         = $apiKey
-        GetParameters = $SearchParameter
-    }
-
-    if ($all) {
-        $offstart = $(if($offset){$offset} Else {0})
-        $callargs = $SearchParameter
-        $callargs.Remove('all')
-
-        while ($true) {
-            $callargs['offset'] = $offstart
-            $callargs['limit'] = $limit
-            $res=Get-SnipeitDepartment @callargs
-            $res
-            if ($res.count -lt $limit) {
-                break
-            }
-            $offstart = $offstart + $limit
+        if ($search -and $id ) {
+            Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
         }
-    } else {
-        $result = Invoke-SnipeitMethod @Parameters
-        $result
+
+        if ($id) {
+        $api= "/api/v1/departments/$id"
+        }
+
+        $Parameters = @{
+            Api           = $api
+            Method        = 'Get'
+            GetParameters = $SearchParameter
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+    }
+    process {
+        if ($all) {
+            $offstart = $(if ($offset) {$offset} Else {0})
+            $callargs = $SearchParameter
+            $callargs.Remove('all')
+
+            while ($true) {
+                $callargs['offset'] = $offstart
+                $callargs['limit'] = $limit
+                $res=Get-SnipeitDepartment @callargs
+                $res
+                if ($res.count -lt $limit) {
+                    break
+                }
+                $offstart = $offstart + $limit
+            }
+        } else {
+            $result = Invoke-SnipeitMethod @Parameters
+            $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }
 

--- a/SnipeitPS/Public/Get-SnipeitLicense.ps1
+++ b/SnipeitPS/Public/Get-SnipeitLicense.ps1
@@ -19,10 +19,10 @@ A return all results, works with -offset and other parameters
 
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
 .EXAMPLE
 Get-SnipeitLicense -search SomeLicense
@@ -98,49 +98,68 @@ function Get-SnipeitLicense() {
         [parameter(ParameterSetName='Search')]
         [switch]$all = $false,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
+    bagin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-    switch($PsCmdlet.ParameterSetName) {
-        'Search' {$apiurl = "$url/api/v1/licenses"}
-        'Get with ID' {$apiurl= "$url/api/v1/licenses/$id"}
-        'Get licenses checked out to user ID' {$apiurl= "$url/api/v1/users/$user_id/licenses"}
-        'Get licenses checked out to asset ID' {$apiurl= "$url/api/v1/hardware/$asset_id/licenses"}
-    }
-
-    $Parameters = @{
-        Uri           = $apiurl
-        Method        = 'Get'
-        Token         = $apiKey
-        GetParameters = $SearchParameter
-    }
-
-    if ($all) {
-        $offstart = $(if($offset){$offset} Else {0})
-        $callargs = $SearchParameter
-        $callargs.Remove('all')
-
-        while ($true) {
-            $callargs['offset'] = $offstart
-            $callargs['limit'] = $limit
-            $res=Get-SnipeitLicense @callargs
-            $res
-            if ($res.count -lt $limit) {
-                break
-            }
-            $offstart = $offstart + $limit
+        switch($PsCmdlet.ParameterSetName) {
+            'Search' {$api = "/api/v1/licenses"}
+            'Get with ID' {$api= "/api/v1/licenses/$id"}
+            'Get licenses checked out to user ID' {$api= "/api/v1/users/$user_id/licenses"}
+            'Get licenses checked out to asset ID' {$api= "/api/v1/hardware/$asset_id/licenses"}
         }
-    } else {
-        $result = Invoke-SnipeitMethod @Parameters
-        $result
+
+        $Parameters = @{
+            Api           = $api
+            Method        = 'Get'
+            GetParameters = $SearchParameter
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+    }
+
+    process {
+        if ($all) {
+            $offstart = $(if ($offset) {$offset} Else {0})
+            $callargs = $SearchParameter
+            $callargs.Remove('all')
+
+            while ($true) {
+                $callargs['offset'] = $offstart
+                $callargs['limit'] = $limit
+                $res=Get-SnipeitLicense @callargs
+                $res
+                if ($res.count -lt $limit) {
+                    break
+                }
+                $offstart = $offstart + $limit
+            }
+        } else {
+            $result = Invoke-SnipeitMethod @Parameters
+            $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }
 

--- a/SnipeitPS/Public/Get-SnipeitLicense.ps1
+++ b/SnipeitPS/Public/Get-SnipeitLicense.ps1
@@ -41,6 +41,12 @@ function Get-SnipeitLicense() {
         [parameter(ParameterSetName='Get with ID')]
         [int]$id,
 
+        [parameter(ParameterSetName='Get licenses checked out to user ID')]
+        [int]$user_id,
+
+        [parameter(ParameterSetName='Get licenses checked out to asset ID')]
+        [int]$asset_id,
+
         [parameter(ParameterSetName='Search')]
         [string]$name,
 
@@ -87,7 +93,8 @@ function Get-SnipeitLicense() {
 
         [parameter(ParameterSetName='Search')]
         [int]$offset,
-
+        [parameter(ParameterSetName='Get licenses checked out to user ID')]
+        [parameter(ParameterSetName='Get licenses checked out to asset ID')]
         [parameter(ParameterSetName='Search')]
         [switch]$all = $false,
 
@@ -102,14 +109,11 @@ function Get-SnipeitLicense() {
 
     $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $apiurl = "$url/api/v1/licenses"
-
-    if ($search -and $id ) {
-         Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
-    }
-
-    if ($id) {
-       $apiurl= "$url/api/v1/licenses/$id"
+    switch($PsCmdlet.ParameterSetName) {
+        'Search' {$apiurl = "$url/api/v1/licenses"}
+        'Get with ID' {$apiurl= "$url/api/v1/licenses/$id"}
+        'Get licenses checked out to user ID' {$apiurl= "$url/api/v1/users/$user_id/licenses"}
+        'Get licenses checked out to asset ID' {$apiurl= "$url/api/v1/hardware/$asset_id/licenses"}
     }
 
     $Parameters = @{

--- a/SnipeitPS/Public/Get-SnipeitLicenseSeat.ps1
+++ b/SnipeitPS/Public/Get-SnipeitLicenseSeat.ps1
@@ -22,10 +22,10 @@ A return all results, works with -offset and other parameters
 
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
 .EXAMPLE
 Get-SnipeitLicenseSeat -id 1
@@ -47,49 +47,68 @@ function Get-SnipeitLicenseSeat() {
 
         [switch]$all = $false,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-    $apiurl = "$url/api/v1/licenses/$id/seats"
+        $api = "/api/v1/licenses/$id/seats"
 
 
-    if ($seat_id) {
-       $apiurl= "$url/api/v1/licenses/$id/seats/$seat_id"
-    }
-
-    $Parameters = @{
-        Uri           = $apiurl
-        Method        = 'Get'
-        Token         = $apiKey
-        GetParameters = $SearchParameter
-    }
-
-    if ($all) {
-        $offstart = $(if($offset){$offset} Else {0})
-        $callargs = $SearchParameter
-        $callargs.Remove('all')
-
-        while ($true) {
-            $callargs['offset'] = $offstart
-            $callargs['limit'] = $limit
-            $res=Get-SnipeitLicenseSeat @callargs
-            $res
-            if ($res.count -lt $limit) {
-                break
-            }
-            $offstart = $offstart + $limit
+        if ($seat_id) {
+        $api= "/api/v1/licenses/$id/seats/$seat_id"
         }
-    } else {
-        $result = Invoke-SnipeitMethod @Parameters
-        $result
+
+        $Parameters = @{
+            Api           = $api
+            Method        = 'Get'
+            GetParameters = $SearchParameter
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+    }
+
+    process {
+        if ($all) {
+            $offstart = $(if ($offset) {$offset} Else {0})
+            $callargs = $SearchParameter
+            $callargs.Remove('all')
+
+            while ($true) {
+                $callargs['offset'] = $offstart
+                $callargs['limit'] = $limit
+                $res=Get-SnipeitLicenseSeat @callargs
+                $res
+                if ($res.count -lt $limit) {
+                    break
+                }
+                $offstart = $offstart + $limit
+            }
+        } else {
+            $result = Invoke-SnipeitMethod @Parameters
+            $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }
 

--- a/SnipeitPS/Public/Get-SnipeitLocation.ps1
+++ b/SnipeitPS/Public/Get-SnipeitLocation.ps1
@@ -18,10 +18,10 @@ Offset to use
 A return all results, works with -offset and other parameters
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
 .EXAMPLE
 Get-SnipeitLocation -search Location1
@@ -31,8 +31,7 @@ Get-SnipeitLocation -id 3
 
 #>
 
-function Get-SnipeitLocation()
-{
+function Get-SnipeitLocation() {
     [CmdletBinding(DefaultParameterSetName = 'Search')]
     Param(
         [parameter(ParameterSetName='Search')]
@@ -54,52 +53,71 @@ function Get-SnipeitLocation()
         [parameter(ParameterSetName='Search')]
         [switch]$all = $false,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        $api = "/api/v1/locations"
 
-    $apiurl = "$url/api/v1/locations"
-
-    if ($search -and $id ) {
-         Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
-    }
-
-    if ($id) {
-       $apiurl= "$url/api/v1/locations/$id"
-    }
-
-    $Parameters = @{
-        Uri           = $apiurl
-        Method        = 'Get'
-        Token         = $apiKey
-        GetParameters = $SearchParameter
-    }
-
-    if ($all) {
-        $offstart = $(if($offset){$offset} Else {0})
-        $callargs = $SearchParameter
-        $callargs.Remove('all')
-
-        while ($true) {
-            $callargs['offset'] = $offstart
-            $callargs['limit'] = $limit
-            $res=Get-SnipeitLocation @callargs
-            $res
-            if ($res.count -lt $limit) {
-                break
-            }
-            $offstart = $offstart + $limit
+        if ($search -and $id ) {
+            Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
         }
-    } else {
-        $result = Invoke-SnipeitMethod @Parameters
-        $result
+
+        if ($id) {
+        $api= "/api/v1/locations/$id"
+        }
+
+        $Parameters = @{
+            Api           = $api
+            Method        = 'Get'
+            GetParameters = $SearchParameter
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+    }
+
+    process {
+        if ($all) {
+            $offstart = $(if ($offset) {$offset} Else {0})
+            $callargs = $SearchParameter
+            $callargs.Remove('all')
+
+            while ($true) {
+                $callargs['offset'] = $offstart
+                $callargs['limit'] = $limit
+                $res=Get-SnipeitLocation @callargs
+                $res
+                if ($res.count -lt $limit) {
+                    break
+                }
+                $offstart = $offstart + $limit
+            }
+        } else {
+            $result = Invoke-SnipeitMethod @Parameters
+            $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }
 

--- a/SnipeitPS/Public/Get-SnipeitManufacturer.ps1
+++ b/SnipeitPS/Public/Get-SnipeitManufacturer.ps1
@@ -18,10 +18,10 @@
     A return all results, works with -offset and other parameters
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
     Get-SnipeitManufacturer -search HP
@@ -32,8 +32,7 @@
     Returns manufacturer with id 3
 
 #>
-function Get-SnipeitManufacturer()
-{
+function Get-SnipeitManufacturer() {
     [CmdletBinding(DefaultParameterSetName = 'Search')]
     Param(
         [parameter(ParameterSetName='Search')]
@@ -55,51 +54,70 @@ function Get-SnipeitManufacturer()
         [parameter(ParameterSetName='Search')]
         [switch]$all = $false,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        $api = "/api/v1/manufacturers"
 
-    $apiurl = "$url/api/v1/manufacturers"
-
-    if ($search -and $id ) {
-         Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
-    }
-
-    if ($id) {
-       $apiurl= "$url/api/v1/manufacturers/$id"
-    }
-
-    $Parameters = @{
-        Uri           = $apiurl
-        Method        = 'Get'
-        Token         = $apiKey
-        GetParameters = $SearchParameter
-    }
-
-    if ($all) {
-        $offstart = $(if($offset){$offset} Else {0})
-        $callargs = $SearchParameter
-        $callargs.Remove('all')
-
-        while ($true) {
-            $callargs['offset'] = $offstart
-            $callargs['limit'] = $limit
-            $res=Get-SnipeitManufacturer @callargs
-            $res
-            if ($res.count -lt $limit) {
-                break
-            }
-            $offstart = $offstart + $limit
+        if ($search -and $id ) {
+            Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
         }
-    } else {
-        $result = Invoke-SnipeitMethod @Parameters
-        $result
+
+        if ($id) {
+        $api= "/api/v1/manufacturers/$id"
+        }
+
+        $Parameters = @{
+            Api           = $api
+            Method        = 'Get'
+            GetParameters = $SearchParameter
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+    }
+
+    process {
+        if ($all) {
+            $offstart = $(if ($offset) {$offset} Else {0})
+            $callargs = $SearchParameter
+            $callargs.Remove('all')
+
+            while ($true) {
+                $callargs['offset'] = $offstart
+                $callargs['limit'] = $limit
+                $res=Get-SnipeitManufacturer @callargs
+                $res
+                if ($res.count -lt $limit) {
+                    break
+                }
+                $offstart = $offstart + $limit
+            }
+        } else {
+            $result = Invoke-SnipeitMethod @Parameters
+            $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }

--- a/SnipeitPS/Public/Get-SnipeitStatus.ps1
+++ b/SnipeitPS/Public/Get-SnipeitStatus.ps1
@@ -18,10 +18,10 @@ Offset to use
 A return all results, works with -offset and other parameters
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
 .EXAMPLE
 Get-SnipeitStatus -search  "Ready to Deploy"
@@ -31,8 +31,7 @@ Get-SnipeitStatus -id 3
 
 #>
 
-function Get-SnipeitStatus()
-{
+function Get-SnipeitStatus() {
     [CmdletBinding(DefaultParameterSetName = 'Search')]
     Param(
         [parameter(ParameterSetName='Search')]
@@ -54,51 +53,70 @@ function Get-SnipeitStatus()
         [parameter(ParameterSetName='Search')]
         [switch]$all = $false,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        $api = "/api/v1/statuslabels"
 
-    $apiurl = "$url/api/v1/statuslabels"
-
-    if ($search -and $id ) {
-         Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
-    }
-
-    if ($id) {
-       $apiurl= "$url/api/v1/statuslabels/$id"
-    }
-
-    $Parameters = @{
-        Uri           = $apiurl
-        Method        = 'Get'
-        Token         = $apiKey
-        GetParameters = $SearchParameter
-    }
-
-    if ($all) {
-        $offstart = $(if($offset){$offset} Else {0})
-        $callargs = $SearchParameter
-        $callargs.Remove('all')
-
-        while ($true) {
-            $callargs['offset'] = $offstart
-            $callargs['limit'] = $limit
-            $res=Get-SnipeitStatus @callargs
-            $res
-            if ($res.count -lt $limit) {
-                break
-            }
-            $offstart = $offstart + $limit
+        if ($search -and $id ) {
+            Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
         }
-    } else {
-        $result = Invoke-SnipeitMethod @Parameters
-        $result
+
+        if ($id) {
+        $api= "/api/v1/statuslabels/$id"
+        }
+
+        $Parameters = @{
+            Api           = $api
+            Method        = 'Get'
+            GetParameters = $SearchParameter
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+    }
+
+    process {
+        if ($all) {
+            $offstart = $(if ($offset) {$offset} Else {0})
+            $callargs = $SearchParameter
+            $callargs.Remove('all')
+
+            while ($true) {
+                $callargs['offset'] = $offstart
+                $callargs['limit'] = $limit
+                $res=Get-SnipeitStatus @callargs
+                $res
+                if ($res.count -lt $limit) {
+                    break
+                }
+                $offstart = $offstart + $limit
+            }
+        } else {
+            $result = Invoke-SnipeitMethod @Parameters
+            $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }

--- a/SnipeitPS/Public/Get-SnipeitSupplier.ps1
+++ b/SnipeitPS/Public/Get-SnipeitSupplier.ps1
@@ -18,10 +18,10 @@ Offset to use
 A return all results, works with -offset and other parameters
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
 .EXAMPLE
 Get-SnipeitSupplier -search MySupplier
@@ -30,8 +30,7 @@ Get-SnipeitSupplier -search MySupplier
 Get-SnipeitSupplier -id 2
 
 #>
-function Get-SnipeitSupplier()
-{
+function Get-SnipeitSupplier() {
     [CmdletBinding(DefaultParameterSetName = 'Search')]
     Param(
         [parameter(ParameterSetName='Search')]
@@ -53,52 +52,71 @@ function Get-SnipeitSupplier()
         [parameter(ParameterSetName='Search')]
         [switch]$all = $false,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $apiurl = "$url/api/v1/suppliers"
+        $api = "/api/v1/suppliers"
 
-    if ($search -and $id ) {
-         Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
-    }
-
-    if ($id) {
-       $apiurl= "$url/api/v1/suppliers/$id"
-    }
-
-    $Parameters = @{
-        Uri           = $apiurl
-        Method        = 'Get'
-        Token         = $apiKey
-        GetParameters = $SearchParameter
-    }
-
-    if ($all) {
-        $offstart = $(if($offset){$offset} Else {0})
-        $callargs = $SearchParameter
-        $callargs.Remove('all')
-
-        while ($true) {
-            $callargs['offset'] = $offstart
-            $callargs['limit'] = $limit
-            $res=Get-SnipeitSupplier @callargs
-            $res
-            if ($res.count -lt $limit) {
-                break
-            }
-            $offstart = $offstart + $limit
+        if ($search -and $id ) {
+            Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
         }
-    } else {
-        $result = Invoke-SnipeitMethod @Parameters
-        $result
+
+        if ($id) {
+        $api= "/api/v1/suppliers/$id"
+        }
+
+        $Parameters = @{
+            Api           = $api
+            Method        = 'Get'
+            GetParameters = $SearchParameter
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+    }
+
+    process {
+        if ($all) {
+            $offstart = $(if ($offset) {$offset} Else {0})
+            $callargs = $SearchParameter
+            $callargs.Remove('all')
+
+            while ($true) {
+                $callargs['offset'] = $offstart
+                $callargs['limit'] = $limit
+                $res=Get-SnipeitSupplier @callargs
+                $res
+                if ($res.count -lt $limit) {
+                    break
+                }
+                $offstart = $offstart + $limit
+            }
+        } else {
+            $result = Invoke-SnipeitMethod @Parameters
+            $result
+        }
+    }
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }
 

--- a/SnipeitPS/Public/Get-SnipeitUser.ps1
+++ b/SnipeitPS/Public/Get-SnipeitUser.ps1
@@ -40,6 +40,10 @@ Get-SnipeitUser -username someuser
 
 .EXAMPLE
 Get-SnipeitUser -email user@somedomain.com
+
+.EXAMPLE
+Get-SnipeitUser -accessory_id 3
+Get users with accessory id 3 has been checked out to
 #>
 
 function Get-SnipeitUser() {
@@ -50,6 +54,9 @@ function Get-SnipeitUser() {
 
         [parameter(ParameterSetName='Get with ID')]
         [string]$id,
+
+        [parameter(ParameterSetName='Get users a specific accessory id has been checked out to')]
+        [string]$accessory_id,
 
         [parameter(ParameterSetName='Search')]
         [int]$company_id,
@@ -80,6 +87,7 @@ function Get-SnipeitUser() {
         [int]$offset,
 
         [parameter(ParameterSetName='Search')]
+        [parameter(ParameterSetName='Get users a specific accessory id has been checked out to')]
         [switch]$all = $false,
 
         [parameter(mandatory = $true)]
@@ -92,16 +100,12 @@ function Get-SnipeitUser() {
     Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
     $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-    $apiurl = "$url/api/v1/users"
-
-    if ($search -and $id ) {
-         Throw "[$($MyInvocation.MyCommand.Name)] Please specify only -search or -id parameter , not both "
+    switch ($PsCmdlet.ParameterSetName) {
+        'Search' { $apiurl = "$url/api/v1/users"}
+        'Get with id'  {$apiurl= "$url/api/v1/users/$id"}
+        'Get users a specific accessory id has been checked out to' {$apiurl= "$url/api/v1/accessories/$accessory_id/checkedout"}
     }
 
-    if ($id) {
-       $apiurl= "$url/api/v1/users/$id"
-    }
     $Parameters = @{
         Uri           = $apiurl
         Method        = 'Get'

--- a/SnipeitPS/Public/New-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/New-SnipeitAccessory.ps1
@@ -54,10 +54,7 @@ ID number of the location the accessory is assigned to
 Min quantity of the accessory before alert is triggered
 
 .PARAMETER image
-Image file name and path for item
-
-.PARAMETER image_delete
-Remove current image
+Accessory image fileame and path
 
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
@@ -111,8 +108,6 @@ function New-SnipeitAccessory() {
 
         [ValidateScript({Test-Path $_})]
         [string]$image,
-
-        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/New-SnipeitAccessory.ps1
@@ -118,12 +118,10 @@ function New-SnipeitAccessory() {
         $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")
     }
 
-    $Body = $Values | ConvertTo-Json;
-
     $Parameters = @{
         Uri    = "$url/api/v1/accessories"
         Method = 'POST'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/New-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/New-SnipeitAccessory.ps1
@@ -23,6 +23,9 @@ ID Number of the company the accessory is assigned to
 .PARAMETER manufacturer_id
 ID number of the manufacturer for this accessory.
 
+.PARAMETER model_number
+Model number for this accessory
+
 .PARAMETER order_number
 Order number for this accessory.
 
@@ -47,7 +50,7 @@ ID number of the supplier for this accessory
 .PARAMETER location_id
 ID number of the location the accessory is assigned to
 
-.PARAMETER min_qty
+.PARAMETER min_amt
 Min quantity of the accessory before alert is triggered
 
 .PARAMETER url
@@ -86,11 +89,13 @@ function New-SnipeitAccessory() {
 
         [string]$order_number,
 
+        [string]$model_number,
+
         [float]$purchase_cost,
 
         [datetime]$purchase_date,
 
-        [int]$min_qty,
+        [int]$min_amt,
 
         [ValidateRange(1, [int]::MaxValue)]
         [int]$supplier_id,

--- a/SnipeitPS/Public/New-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/New-SnipeitAccessory.ps1
@@ -53,6 +53,12 @@ ID number of the location the accessory is assigned to
 .PARAMETER min_amt
 Min quantity of the accessory before alert is triggered
 
+.PARAMETER image
+Image file name and path for item
+
+.PARAMETER image_delete
+Remove current image
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -102,6 +108,11 @@ function New-SnipeitAccessory() {
 
         [ValidateRange(1, [int]::MaxValue)]
         [int]$location_id,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitAsset.ps1
+++ b/SnipeitPS/Public/New-SnipeitAsset.ps1
@@ -42,6 +42,12 @@ Optional Purchase cost of the Asset
 .PARAMETER rtd_location_id
 Optional Default location id for the asset
 
+.PARAMETER image
+Image file name and path for item
+
+.PARAMETER image_delete
+Remove current image
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -113,6 +119,11 @@ function New-SnipeitAsset()
 
         [parameter(mandatory = $false)]
         [int]$rtd_location_id,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitAsset.ps1
+++ b/SnipeitPS/Public/New-SnipeitAsset.ps1
@@ -43,10 +43,7 @@ Optional Purchase cost of the Asset
 Optional Default location id for the asset
 
 .PARAMETER image
-Image file name and path for item
-
-.PARAMETER image_delete
-Remove current image
+Asset image filename and path
 
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
@@ -122,8 +119,6 @@ function New-SnipeitAsset()
 
         [ValidateScript({Test-Path $_})]
         [string]$image,
-
-        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitAsset.ps1
+++ b/SnipeitPS/Public/New-SnipeitAsset.ps1
@@ -137,12 +137,10 @@ function New-SnipeitAsset()
         $Values += $customfields
     }
 
-    $Body = $Values | ConvertTo-Json;
-
     $Parameters = @{
         Uri    = "$url/api/v1/hardware"
         Method = 'Post'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/New-SnipeitAssetMaintenance.ps1
+++ b/SnipeitPS/Public/New-SnipeitAssetMaintenance.ps1
@@ -81,20 +81,19 @@ function New-SnipeitAssetMaintenance() {
 
     $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    if ($values['start_date']) {
-        $values['start_date'] = $values['start_date'].ToString("yyyy-MM-dd")
+    if ($Values['start_date']) {
+        $Values['start_date'] = $Values['start_date'].ToString("yyyy-MM-dd")
     }
 
-    if ($values['completion_date']) {
-        $values['completion_date'] = $values['completion_date'].ToString("yyyy-MM-dd")
+    if ($Values['completion_date']) {
+        $Values['completion_date'] = $Values['completion_date'].ToString("yyyy-MM-dd")
     }
 
-    $Body = $Values | ConvertTo-Json;
 
     $Parameters = @{
         Uri    = "$url/api/v1/maintenances"
         Method = 'Post'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/New-SnipeitAudit.ps1
+++ b/SnipeitPS/Public/New-SnipeitAudit.ps1
@@ -48,12 +48,10 @@ function New-SnipeitAudit()
         $Values += @{"asset_tag" = $tag}
     }
 
-    $Body = $Values | ConvertTo-Json;
-
     $Parameters = @{
         Uri    = "$url/api/v1/hardware/audit"
         Method = 'Post'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/New-SnipeitCategory.ps1
+++ b/SnipeitPS/Public/New-SnipeitCategory.ps1
@@ -24,17 +24,16 @@ If switch is present, send email to user on checkin/checkout
 Category image filename and path
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key API Key for Snipeit.
 
 .EXAMPLE
-New-SnipeitCategory -name "Laptops" -category_type asset -url "Snipe-IT URL here..." -apiKey "API key here..."
+New-SnipeitCategory -name "Laptops" -category_type asset
 #>
 
-function New-SnipeitCategory()
-{
+function New-SnipeitCategory() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
@@ -59,17 +58,17 @@ function New-SnipeitCategory()
         [ValidateScript({Test-Path $_})]
         [string]$image,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
 
     )
     begin {
         Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-        if($eula_text -and $use_default_eula){
+        if ($eula_text -and $use_default_eula) {
             throw 'Dont use -use_defalt_eula if -eula_text is set'
         }
 
@@ -79,17 +78,32 @@ function New-SnipeitCategory()
     process {
 
         $Parameters = @{
-            Uri    = "$url/api/v1/categories"
+            Api    = "/api/v1/categories"
             Method = 'POST'
             Body   = $Values
-            Token  = $apiKey
         }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
             $result = Invoke-SnipeitMethod @Parameters
         }
 
         $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }

--- a/SnipeitPS/Public/New-SnipeitCategory.ps1
+++ b/SnipeitPS/Public/New-SnipeitCategory.ps1
@@ -68,8 +68,6 @@ function New-SnipeitCategory()
         }
 
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-        $Body = $Values | ConvertTo-Json;
     }
 
     process {
@@ -77,7 +75,7 @@ function New-SnipeitCategory()
         $Parameters = @{
             Uri    = "$url/api/v1/categories"
             Method = 'POST'
-            Body   = $Body
+            Body   = $Values
             Token  = $apiKey
         }
 

--- a/SnipeitPS/Public/New-SnipeitCategory.ps1
+++ b/SnipeitPS/Public/New-SnipeitCategory.ps1
@@ -20,6 +20,12 @@ If switch is present, require users to confirm acceptance of assets in this cate
 .PARAMETER checkin_email
 If switch is present, send email to user on checkin/checkout
 
+.PARAMETER image
+Image file name and path for item
+
+.PARAMETER image_delete
+Remove current image
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -47,12 +53,17 @@ function New-SnipeitCategory()
 
         [string]$eula_text,
 
-
         [switch]$use_default_eula,
 
         [switch]$require_acceptance,
 
         [switch]$checkin_email,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
+
         [parameter(mandatory = $true)]
         [string]$url,
 

--- a/SnipeitPS/Public/New-SnipeitCategory.ps1
+++ b/SnipeitPS/Public/New-SnipeitCategory.ps1
@@ -21,10 +21,7 @@ If switch is present, require users to confirm acceptance of assets in this cate
 If switch is present, send email to user on checkin/checkout
 
 .PARAMETER image
-Image file name and path for item
-
-.PARAMETER image_delete
-Remove current image
+Category image filename and path
 
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
@@ -61,8 +58,6 @@ function New-SnipeitCategory()
 
         [ValidateScript({Test-Path $_})]
         [string]$image,
-
-        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitCompany.ps1
+++ b/SnipeitPS/Public/New-SnipeitCompany.ps1
@@ -8,6 +8,12 @@ Creates new company on Snipe-It system
 .PARAMETER name
 Comapany name
 
+.PARAMETER image
+Image file name and path for item
+
+.PARAMETER image_delete
+Remove current image
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -29,6 +35,11 @@ function New-SnipeitCompany()
     Param(
         [parameter(mandatory = $true)]
         [string]$name,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitCompany.ps1
+++ b/SnipeitPS/Public/New-SnipeitCompany.ps1
@@ -41,12 +41,10 @@ function New-SnipeitCompany()
 
     $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $Body = $Values | ConvertTo-Json;
-
     $Parameters = @{
         Uri    = "$url/api/v1/companies"
         Method = 'POST'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/New-SnipeitCompany.ps1
+++ b/SnipeitPS/Public/New-SnipeitCompany.ps1
@@ -12,18 +12,17 @@ Comapany name
 Company image filename and path
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key API Key for Snipeit.
 
 .EXAMPLE
 New-SnipeitCompany -name "Acme Company"
 
 #>
 
-function New-SnipeitCompany()
-{
+function New-SnipeitCompany() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
@@ -36,29 +35,47 @@ function New-SnipeitCompany()
         [ValidateScript({Test-Path $_})]
         [string]$image,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        $Parameters = @{
+            Api    = "/api/v1/companies"
+            Method = 'POST'
+            Body   = $Values
+        }
 
-    $Parameters = @{
-        Uri    = "$url/api/v1/companies"
-        Method = 'POST'
-        Body   = $Values
-        Token  = $apiKey
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
     }
 
-    If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-    {
-        $result = Invoke-SnipeitMethod @Parameters
+    process {
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            $result = Invoke-SnipeitMethod @Parameters
+        }
+
+        $result
     }
 
-    $result
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
+    }
 }
 

--- a/SnipeitPS/Public/New-SnipeitCompany.ps1
+++ b/SnipeitPS/Public/New-SnipeitCompany.ps1
@@ -9,10 +9,7 @@ Creates new company on Snipe-It system
 Comapany name
 
 .PARAMETER image
-Image file name and path for item
-
-.PARAMETER image_delete
-Remove current image
+Company image filename and path
 
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
@@ -38,8 +35,6 @@ function New-SnipeitCompany()
 
         [ValidateScript({Test-Path $_})]
         [string]$image,
-
-        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitComponent.ps1
+++ b/SnipeitPS/Public/New-SnipeitComponent.ps1
@@ -27,10 +27,7 @@ Date accessory was purchased
 Cost of item being purchased.
 
 .PARAMETER image
-Image file name and path for item
-
-.PARAMETER image_delete
-Remove current image
+Component image filename and path
 
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
@@ -73,8 +70,6 @@ function New-SnipeitComponent() {
 
         [ValidateScript({Test-Path $_})]
         [string]$image,
-
-        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitComponent.ps1
+++ b/SnipeitPS/Public/New-SnipeitComponent.ps1
@@ -30,16 +30,15 @@ Cost of item being purchased.
 Component image filename and path
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key API Key for Snipeit.
 
 .EXAMPLE
-An example
+New-SnipeitComponent -name 'Display adapter' -catecory_id 3 -qty 10
 
-.NOTES
-General notes
+
 #>
 
 function New-SnipeitComponent() {
@@ -71,32 +70,51 @@ function New-SnipeitComponent() {
         [ValidateScript({Test-Path $_})]
         [string]$image,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        if ($Values['purchase_date']) {
+            $Values['purchase_date'] = $Values['purchase_date'].ToString("yyyy-MM-dd")
+        }
 
-    if ($Values['purchase_date']) {
-        $Values['purchase_date'] = $Values['purchase_date'].ToString("yyyy-MM-dd")
+        $Parameters = @{
+            Api    = "/api/v1/components"
+            Method = 'POST'
+            Body   = $Values
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
     }
 
-    $Parameters = @{
-        Uri    = "$url/api/v1/components"
-        Method = 'POST'
-        Body   = $Values
-        Token  = $apiKey
+    process {
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            $result = Invoke-SnipeitMethod @Parameters
+        }
+
+        $result
     }
 
-    If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
-        $result = Invoke-SnipeitMethod @Parameters
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
-
-    $result
 }
 

--- a/SnipeitPS/Public/New-SnipeitComponent.ps1
+++ b/SnipeitPS/Public/New-SnipeitComponent.ps1
@@ -26,6 +26,12 @@ Date accessory was purchased
 .PARAMETER purchase_cost
 Cost of item being purchased.
 
+.PARAMETER image
+Image file name and path for item
+
+.PARAMETER image_delete
+Remove current image
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -64,6 +70,11 @@ function New-SnipeitComponent() {
         [datetime]$purchase_date,
 
         [float]$purchase_cost,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitComponent.ps1
+++ b/SnipeitPS/Public/New-SnipeitComponent.ps1
@@ -76,16 +76,14 @@ function New-SnipeitComponent() {
 
     $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    if ($values['purchase_date']) {
-        $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")
+    if ($Values['purchase_date']) {
+        $Values['purchase_date'] = $Values['purchase_date'].ToString("yyyy-MM-dd")
     }
-
-    $Body = $Values | ConvertTo-Json;
 
     $Parameters = @{
         Uri    = "$url/api/v1/components"
         Method = 'POST'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/New-SnipeitConsumable.ps1
+++ b/SnipeitPS/Public/New-SnipeitConsumable.ps1
@@ -114,18 +114,16 @@ function New-SnipeitConsumable()
     begin {
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-        if ($values['purchase_date']) {
+        if ($Values['purchase_date']) {
             $Values['purchase_date'] = $Values['purchase_date'].ToString("yyyy-MM-dd")
         }
-
-        $Body = $Values | ConvertTo-Json;
     }
 
     process {
         $Parameters = @{
             Uri    = "$url/api/v1/consumables"
             Method = 'Post'
-            Body   = $Body
+            Body   = $Values
             Token  = $apiKey
         }
 

--- a/SnipeitPS/Public/New-SnipeitConsumable.ps1
+++ b/SnipeitPS/Public/New-SnipeitConsumable.ps1
@@ -44,6 +44,12 @@ Model number of the consumable in months
 .PARAMETER item_no
 Item number for the consumable
 
+.PARAMETER image
+Image file name and path for item
+
+.PARAMETER image_delete
+Remove current image
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -103,6 +109,11 @@ function New-SnipeitConsumable()
 
         [parameter(mandatory = $false)]
         [string]$item_no,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitConsumable.ps1
+++ b/SnipeitPS/Public/New-SnipeitConsumable.ps1
@@ -45,10 +45,7 @@ Model number of the consumable in months
 Item number for the consumable
 
 .PARAMETER image
-Image file name and path for item
-
-.PARAMETER image_delete
-Remove current image
+Consumable Image filename and path
 
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
@@ -112,8 +109,6 @@ function New-SnipeitConsumable()
 
         [ValidateScript({Test-Path $_})]
         [string]$image,
-
-        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitCustomField.ps1
+++ b/SnipeitPS/Public/New-SnipeitCustomField.ps1
@@ -83,12 +83,10 @@ function New-SnipeitCustomField()
 
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-        $Body = $Values | ConvertTo-Json;
-
         $Parameters = @{
             Uri    = "$url/api/v1/fields"
             Method = 'post'
-            Body   = $Body
+            Body   = $Values
             Token  = $apiKey
         }
     }

--- a/SnipeitPS/Public/New-SnipeitCustomField.ps1
+++ b/SnipeitPS/Public/New-SnipeitCustomField.ps1
@@ -30,17 +30,16 @@
     Any additional text you wish to display under the new form field to make it clearer what the gauges should be.
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
     New-SnipeitCustomField -Name "AntivirusInstalled" -Format "BOOLEAN" -HelpText "Is AntiVirus installed on Asset"
 #>
 
-function New-SnipeitCustomField()
-{
+function New-SnipeitCustomField() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
@@ -68,10 +67,10 @@ function New-SnipeitCustomField()
 
         [string]$custom_format,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
@@ -84,20 +83,33 @@ function New-SnipeitCustomField()
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
         $Parameters = @{
-            Uri    = "$url/api/v1/fields"
+            Api    = "/api/v1/fields"
             Method = 'post'
             Body   = $Values
-            Token  = $apiKey
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Set-SnipeitPSLegacyUrl -url $url
         }
     }
 
     process{
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
             $result = Invoke-SnipeitMethod @Parameters
         }
 
         $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }
 

--- a/SnipeitPS/Public/New-SnipeitDepartment.ps1
+++ b/SnipeitPS/Public/New-SnipeitDepartment.ps1
@@ -17,6 +17,12 @@
     .PARAMETER manager_id
     ID number of manager
 
+    .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER image_delete
+    Remove current image
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -45,6 +51,11 @@ function New-SnipeitDepartment() {
         [int]$manager_id,
 
         [string]$notes,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitDepartment.ps1
+++ b/SnipeitPS/Public/New-SnipeitDepartment.ps1
@@ -18,10 +18,7 @@
     ID number of manager
 
     .PARAMETER image
-    Image file name and path for item
-
-    .PARAMETER image_delete
-    Remove current image
+    Department Image filename and path
 
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command

--- a/SnipeitPS/Public/New-SnipeitDepartment.ps1
+++ b/SnipeitPS/Public/New-SnipeitDepartment.ps1
@@ -21,10 +21,10 @@
     Department Image filename and path
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
     New-SnipeitDepartment -name "Department1" -company_id 1 -localtion_id 1 -manager_id 3
@@ -54,28 +54,47 @@ function New-SnipeitDepartment() {
 
         [switch]$image_delete=$false,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        $Parameters = @{
+            Api    = "/api/v1/departments"
+            Method = 'POST'
+            Body   = $Values
+        }
 
-    $Parameters = @{
-        Uri    = "$url/api/v1/departments"
-        Method = 'POST'
-        Body   = $Values
-        Token  = $apiKey
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
     }
 
-    If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
-        $result = Invoke-SnipeitMethod @Parameters
+    process {
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            $result = Invoke-SnipeitMethod @Parameters
+        }
+
+        $result
     }
 
-    $result
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
+    }
 }
 

--- a/SnipeitPS/Public/New-SnipeitDepartment.ps1
+++ b/SnipeitPS/Public/New-SnipeitDepartment.ps1
@@ -57,12 +57,10 @@ function New-SnipeitDepartment() {
 
     $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $Body = $Values | ConvertTo-Json;
-
     $Parameters = @{
         Uri    = "$url/api/v1/departments"
         Method = 'POST'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/New-SnipeitLicense.ps1
+++ b/SnipeitPS/Public/New-SnipeitLicense.ps1
@@ -128,24 +128,22 @@ function New-SnipeitLicense() {
 
     $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    if ($values['expiration_date']) {
-        $values['expiration_date'] = $values['expiration_date'].ToString("yyyy-MM-dd")
+    if ($Values['expiration_date']) {
+        $Values['expiration_date'] = $Values['expiration_date'].ToString("yyyy-MM-dd")
     }
 
-    if ($values['purchase_date']) {
-        $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")
+    if ($Values['purchase_date']) {
+        $Values['purchase_date'] = $Values['purchase_date'].ToString("yyyy-MM-dd")
     }
 
-    if ($values['termination_date']) {
-        $values['termination_date'] = $values['termination_date'].ToString("yyyy-MM-dd")
+    if ($Values['termination_date']) {
+        $Values['termination_date'] = $Values['termination_date'].ToString("yyyy-MM-dd")
     }
-
-    $Body = $Values | ConvertTo-Json;
 
     $Parameters = @{
         Uri    = "$url/api/v1/licenses"
         Method = 'POST'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/New-SnipeitLocation.ps1
+++ b/SnipeitPS/Public/New-SnipeitLocation.ps1
@@ -89,12 +89,10 @@ function New-SnipeitLocation() {
 
     $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $Body = $Values | ConvertTo-Json;
-
     $Parameters = @{
         Uri    = "$url/api/v1/locations"
         Method = 'post'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/New-SnipeitLocation.ps1
+++ b/SnipeitPS/Public/New-SnipeitLocation.ps1
@@ -39,10 +39,7 @@
     The manager ID of the location
 
     .PARAMETER image
-    Image file name and path for item
-
-    .PARAMETER image_delete
-    Remove current image
+    Location Image filename and path
 
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command

--- a/SnipeitPS/Public/New-SnipeitLocation.ps1
+++ b/SnipeitPS/Public/New-SnipeitLocation.ps1
@@ -38,6 +38,12 @@
     .PARAMETER manager_id
     The manager ID of the location
 
+    .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER image_delete
+    Remove current image
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -77,6 +83,11 @@ function New-SnipeitLocation() {
         [int]$manager_id,
 
         [string]$ldap_ou,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitManufacturer.ps1
+++ b/SnipeitPS/Public/New-SnipeitManufacturer.ps1
@@ -42,13 +42,10 @@ function New-SnipeitManufacturer()
         "name" = $Name
     }
 
-    #Convert Values to JSON format
-    $Body = $Values | ConvertTo-Json;
-
     $Parameters = @{
         Uri    = "$url/api/v1/manufacturers"
         Method = 'post'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/New-SnipeitManufacturer.ps1
+++ b/SnipeitPS/Public/New-SnipeitManufacturer.ps1
@@ -9,7 +9,7 @@
     Name of the Manufacturer
 
     .PARAMETER image
-    Image file name and path for item
+    Manufacturer Image filename and path
 
     .PARAMETER image_delete
     Remove current image

--- a/SnipeitPS/Public/New-SnipeitManufacturer.ps1
+++ b/SnipeitPS/Public/New-SnipeitManufacturer.ps1
@@ -15,17 +15,16 @@
     Remove current image
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
     New-SnipeitManufacturer -name "HP"
 #>
 
-function New-SnipeitManufacturer()
-{
+function New-SnipeitManufacturer() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
@@ -40,30 +39,47 @@ function New-SnipeitManufacturer()
 
         [switch]$image_delete=$false,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    $Values = @{
-        "name" = $Name
+        $Values = @{
+            "name" = $Name
+        }
+
+        $Parameters = @{
+            Api    = "/api/v1/manufacturers"
+            Method = 'post'
+            Body   = $Values
+        }
+
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
     }
+    process {
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            $result = Invoke-SnipeitMethod @Parameters
+        }
 
-    $Parameters = @{
-        Uri    = "$url/api/v1/manufacturers"
-        Method = 'post'
-        Body   = $Values
-        Token  = $apiKey
+        $result
     }
-
-    If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-    {
-        $result = Invoke-SnipeitMethod @Parameters
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
-
-    $result
 }

--- a/SnipeitPS/Public/New-SnipeitManufacturer.ps1
+++ b/SnipeitPS/Public/New-SnipeitManufacturer.ps1
@@ -8,6 +8,12 @@
     .PARAMETER Name
     Name of the Manufacturer
 
+    .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER image_delete
+    Remove current image
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -28,6 +34,11 @@ function New-SnipeitManufacturer()
     Param(
         [parameter(mandatory = $true)]
         [string]$Name,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitModel.ps1
+++ b/SnipeitPS/Public/New-SnipeitModel.ps1
@@ -20,6 +20,12 @@
     .PARAMETER fieldset_id
     Fieldset ID that the asset uses (Custom fields)
 
+    .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER image_delete
+    Remove current image
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -53,6 +59,11 @@ function New-SnipeitModel()
 
         [parameter(mandatory = $true)]
         [int]$fieldset_id,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitModel.ps1
+++ b/SnipeitPS/Public/New-SnipeitModel.ps1
@@ -21,10 +21,7 @@
     Fieldset ID that the asset uses (Custom fields)
 
     .PARAMETER image
-    Image file name and path for item
-
-    .PARAMETER image_delete
-    Remove current image
+    Asset model Image filename and path
 
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
@@ -62,8 +59,6 @@ function New-SnipeitModel()
 
         [ValidateScript({Test-Path $_})]
         [string]$image,
-
-        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitModel.ps1
+++ b/SnipeitPS/Public/New-SnipeitModel.ps1
@@ -73,12 +73,11 @@ function New-SnipeitModel()
     if ($PSBoundParameters.ContainsKey('model_number')) { $Values.Add("model_number", $model_number) }
     if ($PSBoundParameters.ContainsKey('eol')) { $Values.Add("eol", $eol) }
 
-    $Body = $Values | ConvertTo-Json;
 
     $Parameters = @{
         Uri    = "$url/api/v1/models"
         Method = 'post'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/New-SnipeitSupplier.ps1
+++ b/SnipeitPS/Public/New-SnipeitSupplier.ps1
@@ -1,0 +1,117 @@
+<#
+    .SYNOPSIS
+    Creates a supplier
+
+    .DESCRIPTION
+    Creates a new supplier on Snipe-It system
+
+    .PARAMETER name
+    Department Name
+
+    .PARAMETER address
+    Address line 1 of supplier
+
+    .PARAMETER address2
+    Address line 1 of supplier
+
+    .PARAMETER city
+    City
+
+    .PARAMETER state
+    State
+
+    .PARAMETER country
+    Country
+
+    .PARAMETER zip
+    Zip code
+
+    .PARAMETER phone
+    Phone number
+
+    .PARAMETER fax
+    Fax number
+
+    .PARAMETER email
+    Email address
+
+    .PARAMETER contact
+    Contact person
+
+    .PARAMETER notes
+    Email address
+
+     .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER url
+    URL of Snipeit system, can be set using Set-SnipeitInfo command
+
+    .PARAMETER apiKey
+    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+
+    .EXAMPLE
+    New-SnipeitDepartment -name "Department1" -company_id 1 -localtion_id 1 -manager_id 3
+
+#>
+
+function New-SnipeitSupplier() {
+    [CmdletBinding(
+        SupportsShouldProcess = $true,
+        ConfirmImpact = "Low"
+    )]
+
+    Param(
+        [parameter(mandatory = $true)]
+        [string]$name,
+
+        [string]$address,
+
+        [string]$address2,
+
+        [string]$city,
+
+        [string]$state,
+
+        [string]$country,
+
+        [string]$zip,
+
+        [string]$phone,
+
+        [string]$fax,
+
+        [string]$email,
+
+        [string]$contact,
+
+        [string]$notes,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [parameter(mandatory = $true)]
+        [string]$url,
+
+        [parameter(mandatory = $true)]
+        [string]$apiKey
+    )
+
+    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+
+    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+
+    $Parameters = @{
+        Uri    = "$url/api/v1/suppilers"
+        Method = 'POST'
+        Body   = $Values
+        Token  = $apiKey
+    }
+
+    If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+        $result = Invoke-SnipeitMethod @Parameters
+    }
+
+    $result
+}
+

--- a/SnipeitPS/Public/New-SnipeitSupplier.ps1
+++ b/SnipeitPS/Public/New-SnipeitSupplier.ps1
@@ -45,10 +45,10 @@
     Image file name and path for item
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
     New-SnipeitDepartment -name "Department1" -company_id 1 -localtion_id 1 -manager_id 3
@@ -90,28 +90,47 @@ function New-SnipeitSupplier() {
         [ValidateScript({Test-Path $_})]
         [string]$image,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-    Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-    $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        $Parameters = @{
+            Api    = "/api/v1/suppilers"
+            Method = 'POST'
+            Body   = $Values
+        }
 
-    $Parameters = @{
-        Uri    = "$url/api/v1/suppilers"
-        Method = 'POST'
-        Body   = $Values
-        Token  = $apiKey
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
     }
 
-    If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
-        $result = Invoke-SnipeitMethod @Parameters
+    process {
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            $result = Invoke-SnipeitMethod @Parameters
+        }
+
+        $result
     }
 
-    $result
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
+    }
 }
 

--- a/SnipeitPS/Public/New-SnipeitUser.ps1
+++ b/SnipeitPS/Public/New-SnipeitUser.ps1
@@ -120,12 +120,10 @@ function New-SnipeitUser() {
             $Values['password_confirmation'] = $password
     }
 
-    $Body = $Values | ConvertTo-Json;
-
     $Parameters = @{
         Uri    = "$url/api/v1/users"
         Method = 'post'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/New-SnipeitUser.ps1
+++ b/SnipeitPS/Public/New-SnipeitUser.ps1
@@ -50,6 +50,12 @@
     .PARAMETER ldap_import
     Mark user as import from ldap
 
+    .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER image_delete
+    Remove current image
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -104,6 +110,10 @@ function New-SnipeitUser() {
 
         [bool]$ldap_import = $false,
 
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/New-SnipeitUser.ps1
+++ b/SnipeitPS/Public/New-SnipeitUser.ps1
@@ -51,10 +51,7 @@
     Mark user as import from ldap
 
     .PARAMETER image
-    Image file name and path for item
-
-    .PARAMETER image_delete
-    Remove current image
+    User Image file name and path
 
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
@@ -112,8 +109,6 @@ function New-SnipeitUser() {
 
         [ValidateScript({Test-Path $_})]
         [string]$image,
-
-        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Remove-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitAccessory.ps1
@@ -41,7 +41,6 @@ function Remove-SnipeitAccessory ()
             $Parameters = @{
                 Uri    = "$url/api/v1/accessories/$accessory_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitAccessory.ps1
@@ -6,10 +6,10 @@
     .PARAMETER ID
     Unique ID For accessory to be removed
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
     Remove-SnipeitAccessory -ID 44 -Verbose
@@ -18,37 +18,55 @@
     Get-SnipeitAccessory -search needle  | Remove-SnipeitAccessory
 #>
 
-function Remove-SnipeitAccessory ()
-{
+function Remove-SnipeitAccessory () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
 
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
     )
+
     begin {
     }
+
     process {
-        foreach($accessory_id in $id){
+        foreach($accessory_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/accessories/$accessory_id"
+                Api    = "/api/v1/accessories/$accessory_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
-            $result = Invoke-SnipeitMethod @Parameters
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
         }
-        $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitAsset.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitAsset.ps1
@@ -42,7 +42,6 @@ function Remove-SnipeitAsset ()
             $Parameters = @{
                 Uri    = "$url/api/v1/hardware/$asset_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitAsset.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitAsset.ps1
@@ -6,10 +6,10 @@
     .PARAMETER ID
     Unique ID For Asset to be removed
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
     Remove-SnipeitAsset -ID 44 -Verbose
@@ -18,38 +18,56 @@
     Get-SnipeitAsset -serial 123456789  | Remove-SnipeitAsset
 #>
 
-function Remove-SnipeitAsset ()
-{
+function Remove-SnipeitAsset () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
 
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
     )
+
     begin {
         Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
     }
+
     process {
-        foreach($asset_id in $id){
+        foreach($asset_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/hardware/$asset_id"
+                Api    = "/api/v1/hardware/$asset_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
-            $result = Invoke-SnipeitMethod @Parameters
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
         }
-        $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitAssetMaintenance.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitAssetMaintenance.ps1
@@ -46,7 +46,6 @@ function Remove-SnipeitAssetMaintenance {
             $Parameters = @{
                 Uri    = "$url/api/v1/maintenances/$maintenance_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitAssetMaintenance.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitAssetMaintenance.ps1
@@ -1,60 +1,72 @@
+<#
+    .SYNOPSIS
+    Remove asset maintenance from Snipe-it asset system
+
+    .DESCRIPTION
+    Removes asset maintenance event or events from Snipe-it asset system by ID
+
+    .PARAMETER ID
+    Unique ID of the asset maintenance to be removed
+
+    .PARAMETER url
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
+    .PARAMETER url
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
+
+    .EXAMPLE
+    Remove-SnipeitAssetMaintenance -ID 44
+#>
 function Remove-SnipeitAssetMaintenance {
-    <#
-        .SYNOPSIS
-        Remove asset maintenance from Snipe-it asset system
 
-        .DESCRIPTION
-        Removes asset maintenance event or events from Snipe-it asset system by ID
-
-        .PARAMETER ID
-        Unique ID of the asset maintenance to be removed
-
-        .PARAMETER url
-        URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
-
-        .PARAMETER apiKey
-        User's API Key for Snipeit, can be set using Set-SnipeitInfo command
-
-        .EXAMPLE
-        Remove-SnipeitAssetMaintenance -ID 44 -url $url -apiKey $secret -Verbose
-    #>
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
     param (
-        # Asset maintenance ID
         [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]
         $id,
 
-        # Snipeit URL
-        [Parameter(Mandatory = $true)]
-        [string]
-        $url,
+        [parameter(mandatory = $false)]
+        [string]$url,
 
-        # Snipeit ApiKey
-        [Parameter(Mandatory = $true)]
-        [string]
-        $apiKey
+        [parameter(mandatory = $false)]
+        [string]$apiKey
     )
+
     begin {
         Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
     }
+
     process {
-        foreach($maintenance_id in $id){
+        foreach($maintenance_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/maintenances/$maintenance_id"
+                Api    = "/api/v1/maintenances/$maintenance_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-            {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitCategory.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitCategory.ps1
@@ -41,7 +41,6 @@ function Remove-SnipeitCategory ()
             $Parameters = @{
                 Uri    = "$url/api/v1/categories/$category_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitCategory.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitCategory.ps1
@@ -6,49 +6,66 @@
     .PARAMETER ID
     Unique ID For categoryto be removed
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
-    Remove-SnipeitCategory -ID 44 -Verbose
+    Remove-SnipeitCategory -ID 44
 
     .EXAMPLE
     Get-SnipeitCategory -search something  | Remove-SnipeitCategory
 #>
 
-function Remove-SnipeitCategory ()
-{
+function Remove-SnipeitCategory () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
+
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
 
     )
     begin {
     }
     process {
-        foreach($category_id in $id){
+        foreach($category_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/categories/$category_id"
+                Api    = "/api/v1/categories/$category_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
-            $result = Invoke-SnipeitMethod @Parameters
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
         }
-        $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitCompany.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitCompany.ps1
@@ -6,49 +6,66 @@
     .PARAMETER ID
     Unique ID For Company to be removed
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
-    Remove-SnipeitCompany -ID 44 -Verbose
+    Remove-SnipeitCompany -ID 44
 
     .EXAMPLE
     Get-SnipeitCompany | | Where-object {$_.name -like '*some*'} | Remove-SnipeitCompany
 #>
 
-function Remove-SnipeitCompany ()
-{
+function Remove-SnipeitCompany () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
+
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
 
     )
     begin {
     }
     process {
-        foreach($company_id in $id){
+        foreach($company_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/companies/$company_id"
+                Api    = "/api/v1/companies/$company_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
-            $result = Invoke-SnipeitMethod @Parameters
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
         }
-        $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitCompany.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitCompany.ps1
@@ -41,7 +41,6 @@ function Remove-SnipeitCompany ()
             $Parameters = @{
                 Uri    = "$url/api/v1/companies/$company_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitComponent.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitComponent.ps1
@@ -41,7 +41,6 @@ function Remove-SnipeitComponent ()
             $Parameters = @{
                 Uri    = "$url/api/v1/components/$component_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitComponent.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitComponent.ps1
@@ -6,49 +6,67 @@
     .PARAMETER IDs
     Unique ID For component to be removed
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
-    Remove-SnipeitComponent -ID 44 -Verbose
+    Remove-SnipeitComponent -ID 44
 
     .EXAMPLE
     Get-SnipeitComponent -search 123456789  | Remove-SnipeitComponent
 #>
 
-function Remove-SnipeitComponent ()
-{
+function Remove-SnipeitComponent () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
 
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
     )
+
     begin {
     }
+
     process {
-        foreach($component_id in $id){
+        foreach($component_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/components/$component_id"
+                Api    = "/api/v1/components/$component_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
-            $result = Invoke-SnipeitMethod @Parameters
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
         }
-        $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitConsumable.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitConsumable.ps1
@@ -7,49 +7,67 @@
     Unique ID For consumable to be removed
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
-    Remove-SnipeitConsumable -ID 44 -Verbose
+    Remove-SnipeitConsumable -ID 44
 
     .EXAMPLE
-    Get-SnipeitConsumable -search "paper"  | Remove-Snipeitconsumable
+    Get-SnipeitConsumable -search "paper"  | Remove-SnipeitConsumable
 #>
 
-function Remove-SnipeitConsumable ()
-{
+function Remove-SnipeitConsumable () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
 
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
     )
+
     begin {
     }
+
     process {
-        foreach($consumable_id in $id){
+        foreach($consumable_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/consumables/$consumable_id"
+                Api    = "/api/v1/consumables/$consumable_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
-            $result = Invoke-SnipeitMethod @Parameters
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
         }
-        $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitConsumable.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitConsumable.ps1
@@ -42,7 +42,6 @@ function Remove-SnipeitConsumable ()
             $Parameters = @{
                 Uri    = "$url/api/v1/consumables/$consumable_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitCustomField.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitCustomField.ps1
@@ -41,7 +41,6 @@ function Remove-SnipeitCustomField ()
             $Parameters = @{
                 Uri    = "$url/api/v1/fields/$field_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitDepartment.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitDepartment.ps1
@@ -6,49 +6,66 @@
     .PARAMETER ID
     Unique ID For department to be removed
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
-    Remove-SnipeitDepartment -ID 44 -Verbose
+    Remove-SnipeitDepartment -ID 44
 
     .EXAMPLE
     Get-SnipeitDepartment | Where-object {$_.name -like '*head*'} | Remove-SnipeitDepartment
 #>
 
-function Remove-SnipeitDepartment ()
-{
+function Remove-SnipeitDepartment () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
+
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
 
     )
     begin {
     }
     process {
-        foreach($department_id in $id){
+        foreach($department_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/departments/$department_id"
+                Api    = "/api/v1/departments/$department_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
-            $result = Invoke-SnipeitMethod @Parameters
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
         }
-        $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitDepartment.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitDepartment.ps1
@@ -41,7 +41,6 @@ function Remove-SnipeitDepartment ()
             $Parameters = @{
                 Uri    = "$url/api/v1/departments/$department_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitLicense.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitLicense.ps1
@@ -41,7 +41,6 @@ function Remove-SnipeitLicense ()
             $Parameters = @{
                 Uri    = "$url/api/v1/licenses/$license_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitLicense.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitLicense.ps1
@@ -6,49 +6,67 @@
     .PARAMETER ID
     Unique ID For licence to be removed
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
-    Remove-SnipeitLicence -ID 44 -Verbose
+    Remove-SnipeitLicence -ID 44
 
     .EXAMPLE
     Get-SnipeitLicence -product_key 123456789  | Remove-SnipeitLicense
 #>
 
-function Remove-SnipeitLicense ()
-{
+function Remove-SnipeitLicense () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
 
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
     )
+
     begin {
     }
+
     process {
-        foreach($license_id in $id){
+        foreach($license_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/licenses/$license_id"
+                Api    = "/api/v1/licenses/$license_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
-            $result = Invoke-SnipeitMethod @Parameters
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
         }
-        $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitLocation.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitLocation.ps1
@@ -41,7 +41,6 @@ function Remove-SnipeitLocation ()
             $Parameters = @{
                 Uri    = "$url/api/v1/locations/$asset_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitLocation.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitLocation.ps1
@@ -6,49 +6,67 @@
     .PARAMETER ID
     Unique ID For location to be removed
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
-    Remove-SnipeitLocation -ID 44 -Verbose
+    Remove-SnipeitLocation -ID 44
 
     .EXAMPLE
     Get-SnipeitLocation -city Arkham  | Remove-SnipeitLocation
 #>
 
-function Remove-SnipeitLocation ()
-{
+function Remove-SnipeitLocation () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
 
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
     )
+
     begin {
     }
+
     process {
-        foreach($location_id in $id){
+        foreach($location_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/locations/$asset_id"
+                Api    = "/api/v1/locations/$asset_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
-            $result = Invoke-SnipeitMethod @Parameters
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
         }
-        $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitManufacturer.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitManufacturer.ps1
@@ -6,49 +6,68 @@
     .PARAMETER ID
     Unique ID For manufacturer to be removed
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
-    Remove-SnipeitManufacturer -ID 44 -Verbose
+    Remove-SnipeitManufacturer -ID 44
 
     .EXAMPLE
     Get-SnipeitManufacturer | Where-object {$_.name -like '*something*'}  | Remove-SnipeitManufacturer
 #>
 
-function Remove-SnipeitManufacturer ()
-{
+function Remove-SnipeitManufacturer () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
 
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
     )
+
     begin {
     }
+
     process {
-        foreach($manufacturer_id in $id){
+        foreach($manufacturer_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/manufacturers/$manufacturer_id"
+                Api    = "/api/v1/manufacturers/$manufacturer_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
-            $result = Invoke-SnipeitMethod @Parameters
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
         }
-        $result
+
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitManufacturer.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitManufacturer.ps1
@@ -41,7 +41,6 @@ function Remove-SnipeitManufacturer ()
             $Parameters = @{
                 Uri    = "$url/api/v1/manufacturers/$manufacturer_id_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitManufacturer.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitManufacturer.ps1
@@ -39,7 +39,7 @@ function Remove-SnipeitManufacturer ()
     process {
         foreach($manufacturer_id in $id){
             $Parameters = @{
-                Uri    = "$url/api/v1/manufacturers/$manufacturer_id_id"
+                Uri    = "$url/api/v1/manufacturers/$manufacturer_id"
                 Method = 'Delete'
                 Token  = $apiKey
             }

--- a/SnipeitPS/Public/Remove-SnipeitModel.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitModel.ps1
@@ -6,49 +6,67 @@
     .PARAMETER ID
     Unique ID For Model to be removed
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
-    Remove-SnipeitModel -ID 44 -Verbose
+    Remove-SnipeitModel -ID 44
 
     .EXAMPLE
     Get-SnipeitModel -search needle  | Remove-SnipeitModel
 #>
 
-function Remove-SnipeitModel ()
-{
+function Remove-SnipeitModel () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
 
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
     )
+
     begin {
     }
+
     process {
-        foreach($model_id in $id){
+        foreach($model_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/models/$model_id"
+                Api    = "/api/v1/models/$model_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
-            $result = Invoke-SnipeitMethod @Parameters
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
         }
-        $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitModel.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitModel.ps1
@@ -41,7 +41,6 @@ function Remove-SnipeitModel ()
             $Parameters = @{
                 Uri    = "$url/api/v1/models/$model_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitSupplier.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitSupplier.ps1
@@ -1,0 +1,54 @@
+<#
+    .SYNOPSIS
+    Removes supplier from Snipe-it asset system
+    .DESCRIPTION
+    Removes supplier or multiple manufacturers from Snipe-it asset system
+    .PARAMETER ID
+    Unique ID For supplier to be removed
+    .PARAMETER url
+    URL of Snipeit system, can be set using Set-SnipeitInfo command
+
+    .PARAMETER apiKey
+    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+
+    .EXAMPLE
+    Remove-SnipeitSupplier -ID 44
+
+    .EXAMPLE
+    Get-SnipeitSupplier | Where-object {$_.name -like '*something*'}  | Remove-SnipeitSupplier
+#>
+
+function Remove-SnipeitSupplier ()
+{
+    [CmdletBinding(
+        SupportsShouldProcess = $true,
+        ConfirmImpact = "Low"
+    )]
+
+    Param(
+    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [int[]]$id,
+    [parameter(mandatory = $true)]
+        [string]$URL,
+    [parameter(mandatory = $true)]
+        [string]$APIKey
+
+    )
+    begin {
+    }
+    process {
+        foreach($suppliers_id in $id){
+            $Parameters = @{
+                Uri    = "$url/api/v1/suppliers/$supplier_id"
+                Method = 'Delete'
+                Token  = $apiKey
+            }
+
+        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
+        {
+            $result = Invoke-SnipeitMethod @Parameters
+        }
+        $result
+        }
+    }
+}

--- a/SnipeitPS/Public/Remove-SnipeitSupplier.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitSupplier.ps1
@@ -6,10 +6,10 @@
     .PARAMETER ID
     Unique ID For supplier to be removed
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
     Remove-SnipeitSupplier -ID 44
@@ -18,37 +18,55 @@
     Get-SnipeitSupplier | Where-object {$_.name -like '*something*'}  | Remove-SnipeitSupplier
 #>
 
-function Remove-SnipeitSupplier ()
-{
+function Remove-SnipeitSupplier () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
         [int[]]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
 
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
     )
+
     begin {
     }
+
     process {
-        foreach($suppliers_id in $id){
+        foreach($suppliers_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/suppliers/$supplier_id"
+                Api    = "/api/v1/suppliers/$supplier_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
-            $result = Invoke-SnipeitMethod @Parameters
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
         }
-        $result
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Remove-SnipeitUser.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitUser.ps1
@@ -41,7 +41,6 @@ function Remove-SnipeitUser ()
             $Parameters = @{
                 Uri    = "$url/api/v1/users/$user_id"
                 Method = 'Delete'
-                Body   = '{}'
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Remove-SnipeitUser.ps1
+++ b/SnipeitPS/Public/Remove-SnipeitUser.ps1
@@ -7,31 +7,32 @@
     Unique ID For User to be removed
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
     Remove-SnipeitUser -ID 44 -url $url -apiKey $secret -Verbose
 #>
 
-function Remove-SnipeitUser ()
-{
+function Remove-SnipeitUser () {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
     )]
 
     Param(
-    [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
-        [int]$id,
-    [parameter(mandatory = $true)]
-        [string]$URL,
-    [parameter(mandatory = $true)]
-        [string]$APIKey
+        [parameter(mandatory = $true,ValueFromPipelineByPropertyName)]
+        [int[]]$id,
 
+        [parameter(mandatory = $false)]
+        [string]$url,
+
+        [parameter(mandatory = $false)]
+        [string]$apiKey
     )
+
     begin{
         Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
     }
@@ -39,17 +40,32 @@ function Remove-SnipeitUser ()
     process {
         foreach($user_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/users/$user_id"
+                Api    = "/api/v1/users/$user_id"
                 Method = 'Delete'
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-            {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Reset-SnipeitAccessoryOwner.ps1
+++ b/SnipeitPS/Public/Reset-SnipeitAccessoryOwner.ps1
@@ -10,10 +10,10 @@
     Use Get-SnipeitAccessoryOwner to find out nooded value
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
        .EXAMPLE
     To get the accessories_users table for specific accessory id number
@@ -25,8 +25,7 @@
     Get-SnipeitAccessoryOwner -assigned_pivot_id xxx
 
 #>
-function Reset-SnipeitAccessoryOwner()
-{
+function Reset-SnipeitAccessoryOwner() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Medium"
@@ -36,24 +35,38 @@ function Reset-SnipeitAccessoryOwner()
         [parameter(mandatory = $true)]
         [int]$assigned_pivot_id,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
     $Parameters = @{
-        Uri    = "$url/api/v1/accessories/$assigned_pivot_id/checkin"
+        Api    = "/api/v1/accessories/$assigned_pivot_id/checkin"
         Method = 'Post'
         Body   = @{}
-        Token  = $apiKey
     }
 
-    If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-    {
+    if ($PSBoundParameters.ContainsKey('apiKey')) {
+        Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+        Set-SnipeitPSLegacyApiKey -apiKey $apikey
+    }
+
+    if ($PSBoundParameters.ContainsKey('url')) {
+        Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+        Set-SnipeitPSLegacyUrl -url $url
+    }
+
+    if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
         $result = Invoke-SnipeitMethod @Parameters
     }
 
+    # reset legacy sessions
+    if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+        Reset-SnipeitPSLegacyApi
+    }
+
     return $result
+
 }

--- a/SnipeitPS/Public/Reset-SnipeitAccessoryOwner.ps1
+++ b/SnipeitPS/Public/Reset-SnipeitAccessoryOwner.ps1
@@ -46,7 +46,7 @@ function Reset-SnipeitAccessoryOwner()
     $Parameters = @{
         Uri    = "$url/api/v1/accessories/$assigned_pivot_id/checkin"
         Method = 'Post'
-        Body   = '{}'
+        Body   = @{}
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/Reset-SnipeitAssetOwner.ps1
+++ b/SnipeitPS/Public/Reset-SnipeitAssetOwner.ps1
@@ -57,12 +57,10 @@ function Reset-SnipeitAssetOwner() {
     if ($PSBoundParameters.ContainsKey('location_id')) { $Values.Add("location_id", $location_id) }
     if ($PSBoundParameters.ContainsKey('status_id')) { $Values.Add("status_id", $status_id) }
 
-    $Body = $Values | ConvertTo-Json;
-
     $Parameters = @{
         Uri    = "$url/api/v1/hardware/$id/checkin"
         Method = 'POST'
-        Body   = $Body
+        Body   = $Values
         Token  = $apiKey
     }
 

--- a/SnipeitPS/Public/Reset-SnipeitAssetOwner.ps1
+++ b/SnipeitPS/Public/Reset-SnipeitAssetOwner.ps1
@@ -17,13 +17,11 @@
     Notes about checkin
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
-
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfoeItInfo command
-
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
     .EXAMPLE
-    Remove-SnipeitUser -ID 44 -url $url -apiKey $secret -Verbose
+    Remove-SnipeitUser -ID 44
 #>
 function Reset-SnipeitAssetOwner() {
     [CmdletBinding(
@@ -41,10 +39,10 @@ function Reset-SnipeitAssetOwner() {
 
         [string]$notes,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
@@ -58,14 +56,28 @@ function Reset-SnipeitAssetOwner() {
     if ($PSBoundParameters.ContainsKey('status_id')) { $Values.Add("status_id", $status_id) }
 
     $Parameters = @{
-        Uri    = "$url/api/v1/hardware/$id/checkin"
+        Api    = "/api/v1/hardware/$id/checkin"
         Method = 'POST'
         Body   = $Values
-        Token  = $apiKey
     }
 
-    If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+    if ($PSBoundParameters.ContainsKey('apiKey')) {
+        Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+        Set-SnipeitPSLegacyApiKey -apiKey $apikey
+    }
+
+    if ($PSBoundParameters.ContainsKey('url')) {
+        Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+        Set-SnipeitPSLegacyUrl -url $url
+    }
+
+    if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
         $result = Invoke-SnipeitMethod @Parameters
+    }
+
+    # reset legacy sessions
+    if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+        Reset-SnipeitPSLegacyApi
     }
 
     return $result

--- a/SnipeitPS/Public/Set-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAccessory.ps1
@@ -44,6 +44,12 @@ ID number of the supplier for this accessory
 .PARAMETER location_id
 ID number of the location the accessory is assigned to
 
+.PARAMETER image
+Image file name and path for item
+
+.PARAMETER image_delete
+Remove current image
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
 
@@ -89,6 +95,11 @@ function Set-SnipeitAccessory() {
         [Nullable[System.Int32]]$supplier_id,
 
         [Nullable[System.Int32]]$location_id,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAccessory.ps1
@@ -26,6 +26,9 @@ ID Number of the company the accessory is assigned to
 .PARAMETER manufacturer_id
 ID number of the manufacturer for this accessory.
 
+.PARAMETER model_number
+Model number for this accessory
+
 .PARAMETER order_number
 Order number for this accessory.
 
@@ -85,6 +88,7 @@ function Set-SnipeitAccessory() {
 
         [Nullable[System.Int32]]$manufacturer_id,
 
+        [string]$model_number,
 
         [string]$order_number,
 
@@ -120,7 +124,7 @@ function Set-SnipeitAccessory() {
         foreach($accessory_id in $id){
             $Parameters = @{
                 Uri    = "$url/api/v1/accessories/$accessory_id"
-                Method = 'Patch'
+                Method = 'Put'
                 Body   = $Body
                 Token  = $apiKey
             }

--- a/SnipeitPS/Public/Set-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAccessory.ps1
@@ -38,23 +38,11 @@ Cost of item being purchased.
 .PARAMETER purchase_date
 Date accessory was purchased
 
-.PARAMETER order_number
-Order number for this accessory.
-
-.PARAMETER purchase_cost
-Cost of item being purchased.
-
-.PARAMETER purchase_date
-Date accessory was purchased
-
 .PARAMETER supplier_id
 ID number of the supplier for this accessory
 
 .PARAMETER location_id
 ID number of the location the accessory is assigned to
-
-.PARAMETER min_qty
-Min quantity of the accessory before alert is triggered
 
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
@@ -100,6 +88,8 @@ function Set-SnipeitAccessory() {
 
         [Nullable[System.Int32]]$supplier_id,
 
+        [Nullable[System.Int32]]$location_id,
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -112,20 +102,18 @@ function Set-SnipeitAccessory() {
 
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-        if ($values['purchase_date']) {
-            $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")
+        if ($Values['purchase_date']) {
+            $Values['purchase_date'] = $Values['purchase_date'].ToString("yyyy-MM-dd")
         }
 
-        $Body = $Values | ConvertTo-Json;
-        Write-Verbose "Body: $Body"
         }
 
     process {
         foreach($accessory_id in $id){
             $Parameters = @{
                 Uri    = "$url/api/v1/accessories/$accessory_id"
-                Method = 'Put'
-                Body   = $Body
+                Method = 'Patch'
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAccessory.ps1
@@ -50,6 +50,9 @@ Image file name and path for item
 .PARAMETER image_delete
 Remove current image
 
+.PARAMETER RequestType
+Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
 
@@ -101,6 +104,9 @@ function Set-SnipeitAccessory() {
 
         [switch]$image_delete=$false,
 
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -123,7 +129,7 @@ function Set-SnipeitAccessory() {
         foreach($accessory_id in $id){
             $Parameters = @{
                 Uri    = "$url/api/v1/accessories/$accessory_id"
-                Method = 'Patch'
+                Method = $RequestType
                 Body   = $Values
                 Token  = $apiKey
             }

--- a/SnipeitPS/Public/Set-SnipeitAccessory.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAccessory.ps1
@@ -54,11 +54,10 @@ Remove current image
 Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfoeItInfoeItInfo command
-
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 .EXAMPLE
 Set-SnipeitAccessory -id 1 -qty 3
 
@@ -107,10 +106,10 @@ function Set-SnipeitAccessory() {
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
@@ -126,20 +125,36 @@ function Set-SnipeitAccessory() {
         }
 
     process {
-        foreach($accessory_id in $id){
+        foreach($accessory_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/accessories/$accessory_id"
+                Api    = "/api/v1/accessories/$accessory_id"
                 Method = $RequestType
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }
 

--- a/SnipeitPS/Public/Set-SnipeitAccessoryOwner.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAccessoryOwner.ps1
@@ -46,8 +46,6 @@ function Set-SnipeitAccessoryOwner()
     )
     begin{
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-        $Body = $Values | ConvertTo-Json;
     }
 
     process {
@@ -55,7 +53,7 @@ function Set-SnipeitAccessoryOwner()
             $Parameters = @{
                 Uri    = "$url/api/v1/accessories/$accessory_id/checkout"
                 Method = 'POST'
-                Body   = $Body
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitAccessoryOwner.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAccessoryOwner.ps1
@@ -14,16 +14,15 @@
     Notes about checkout
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
     Set-SnipeitAccessoryOwner -id 1 -assigned_id 1  -note "testing check out to user"
 #>
-function Set-SnipeitAccessoryOwner()
-{
+function Set-SnipeitAccessoryOwner() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Medium"
@@ -38,10 +37,10 @@ function Set-SnipeitAccessoryOwner()
 
         [string] $note,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
     begin{
@@ -49,20 +48,35 @@ function Set-SnipeitAccessoryOwner()
     }
 
     process {
-        foreach($accessory_id in $id){
+        foreach($accessory_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/accessories/$accessory_id/checkout"
+                Api    = "/api/v1/accessories/$accessory_id/checkout"
                 Method = 'POST'
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-            {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             return $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitAsset.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAsset.ps1
@@ -53,8 +53,14 @@
     .PARAMETER notes
     Notes about asset
 
+    .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER image_delete
+    Remove current image
+
     .PARAMETER RequestType
-    Http request type to send Snipe IT system. Defaults to Put youc use Patch if needed
+    Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
@@ -121,6 +127,11 @@ function Set-SnipeitAsset()
 
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitAsset.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAsset.ps1
@@ -63,10 +63,10 @@
     Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfoeItInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .PARAMETER customfields
     Hastable of custom fields and extra fields that need passing through to Snipeit
@@ -81,8 +81,7 @@
     Get-SnipeitAsset -serial 12345678 | Set-SnipeitAsset -notes 'Just updated'
 #>
 
-function Set-SnipeitAsset()
-{
+function Set-SnipeitAsset() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Medium"
@@ -133,10 +132,10 @@ function Set-SnipeitAsset()
 
         [switch]$image_delete=$false,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey,
 
         [Alias('CustomValues')]
@@ -151,28 +150,42 @@ function Set-SnipeitAsset()
             $Values['purchase_date'] = $Values['purchase_date'].ToString("yyyy-MM-dd")
         }
 
-        if ($customfields)
-        {
+        if ($customfields) {
             $Values += $customfields
         }
 
     }
 
     process {
-        foreach($asset_id in $id){
+        foreach($asset_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/hardware/$asset_id"
+                Api    = "/api/v1/hardware/$asset_id"
                 Method = $RequestType
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-            {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitAsset.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAsset.ps1
@@ -136,8 +136,8 @@ function Set-SnipeitAsset()
 
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-        if ($values['purchase_date']) {
-            $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")
+        if ($Values['purchase_date']) {
+            $Values['purchase_date'] = $Values['purchase_date'].ToString("yyyy-MM-dd")
         }
 
         if ($customfields)
@@ -145,7 +145,6 @@ function Set-SnipeitAsset()
             $Values += $customfields
         }
 
-        $Body = $Values | ConvertTo-Json;
     }
 
     process {
@@ -153,7 +152,7 @@ function Set-SnipeitAsset()
             $Parameters = @{
                 Uri    = "$url/api/v1/hardware/$asset_id"
                 Method = $RequestType
-                Body   = $Body
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitAssetOwner.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAssetOwner.ps1
@@ -71,11 +71,11 @@ function Set-SnipeitAssetOwner()
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
         if ($Values['expected_checkin']) {
-            $Values['expected_checkin'] = $values['expected_checkin'].ToString("yyyy-MM-dd")
+            $Values['expected_checkin'] = $Values['expected_checkin'].ToString("yyyy-MM-dd")
         }
 
         if ($Values['checkout_at']) {
-            $Values['checkout_at'] = $values['checkout_at'].ToString("yyyy-MM-dd")
+            $Values['checkout_at'] = $Values['checkout_at'].ToString("yyyy-MM-dd")
         }
 
         switch ($checkout_to_type)
@@ -88,8 +88,6 @@ function Set-SnipeitAssetOwner()
         #This can be removed now
         if($Values.ContainsKey('assigned_id')){$Values.Remove('assigned_id')}
 
-        $Body = $Values | ConvertTo-Json;
-
     }
 
     process{
@@ -97,7 +95,7 @@ function Set-SnipeitAssetOwner()
             $Parameters = @{
                 Uri    = "$url/api/v1/hardware/$asset_id/checkout"
                 Method = 'POST'
-                Body   = $Body
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitAssetOwner.ps1
+++ b/SnipeitPS/Public/Set-SnipeitAssetOwner.ps1
@@ -10,6 +10,9 @@
     .PARAMETER assigned_id
     Id of target user , location or asset
 
+    .PARAMETER checkout_to_type
+    Checkout asset to one of following types user, location, asset
+
     .PARAMETER note
     Notes about checkout
 

--- a/SnipeitPS/Public/Set-SnipeitCategory.ps1
+++ b/SnipeitPS/Public/Set-SnipeitCategory.ps1
@@ -26,6 +26,9 @@ Image file name and path for item
 .PARAMETER image_delete
 Remove current image
 
+.PARAMETER RequestType
+Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -65,6 +68,9 @@ function Set-SnipeitCategory()
 
         [switch]$image_delete=$false,
 
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -83,7 +89,7 @@ function Set-SnipeitCategory()
         foreach($category_id in $id){
             $Parameters = @{
                 Uri    = "$url/api/v1/categories/$category_id"
-                Method = 'Put'
+                Method = $RequestType
                 Body   = $values
                 Token  = $apiKey
             }

--- a/SnipeitPS/Public/Set-SnipeitCategory.ps1
+++ b/SnipeitPS/Public/Set-SnipeitCategory.ps1
@@ -66,8 +66,6 @@ function Set-SnipeitCategory()
         Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-        $Body = $Values | ConvertTo-Json;
     }
 
     process {
@@ -75,7 +73,7 @@ function Set-SnipeitCategory()
             $Parameters = @{
                 Uri    = "$url/api/v1/categories/$category_id"
                 Method = 'Put'
-                Body   = $Body
+                Body   = $values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitCategory.ps1
+++ b/SnipeitPS/Public/Set-SnipeitCategory.ps1
@@ -8,12 +8,6 @@ Name of new category to be created
 .PARAMETER type
 Type of new category to be created (asset, accessory, consumable, component, license)
 
-.PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
-
-.PARAMETER apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
-
 .PARAMETER use_default_eula
 If switch is present, use the primary default EULA
 
@@ -25,6 +19,18 @@ If switch is present, require users to confirm acceptance of assets in this cate
 
 .PARAMETER checkin_email
 Should the user be emailed the EULA and/or an acceptance confirmation email when this item is checked in?
+
+.PARAMETER image
+Image file name and path for item
+
+.PARAMETER image_delete
+Remove current image
+
+.PARAMETER url
+URL of Snipeit system, can be set using Set-SnipeitInfo command
+
+.PARAMETER apiKey
+User's API Key for Snipeit, can be set using Set-SnipeitInfo command
 
 .EXAMPLE
 Set-SnipeitCategory -id 4 -name "Laptops"
@@ -53,6 +59,11 @@ function Set-SnipeitCategory()
         [bool]$require_acceptance,
 
         [bool]$checkin_email,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitCategory.ps1
+++ b/SnipeitPS/Public/Set-SnipeitCategory.ps1
@@ -30,17 +30,16 @@ Remove current image
 Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key API Key for Snipeit.
 
 .EXAMPLE
 Set-SnipeitCategory -id 4 -name "Laptops"
 #>
 
-function Set-SnipeitCategory()
-{
+function Set-SnipeitCategory() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
@@ -71,10 +70,10 @@ function Set-SnipeitCategory()
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
 
     )
@@ -86,20 +85,35 @@ function Set-SnipeitCategory()
     }
 
     process {
-        foreach($category_id in $id){
+        foreach($category_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/categories/$category_id"
+                Api    = "/api/v1/categories/$category_id"
                 Method = $RequestType
                 Body   = $values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-            {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitCompany.ps1
+++ b/SnipeitPS/Public/Set-SnipeitCompany.ps1
@@ -11,6 +11,12 @@ ID number of company
 .PARAMETER name
 Company name
 
+.PARAMETER image
+Image file name and path for item
+
+.PARAMETER image_delete
+Remove current image
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -36,6 +42,11 @@ function Set-SnipeitCompany()
 
         [parameter(mandatory = $true)]
         [string]$name,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitCompany.ps1
+++ b/SnipeitPS/Public/Set-SnipeitCompany.ps1
@@ -45,9 +45,7 @@ function Set-SnipeitCompany()
     )
 
     begin{
-        $values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-        $Body = $values | ConvertTo-Json;
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
     }
 
     process{
@@ -55,7 +53,7 @@ function Set-SnipeitCompany()
             $Parameters = @{
                 Uri    = "$url/api/v1/companies/$company_id"
                 Method = 'Patch'
-                Body   = $Body
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitCompany.ps1
+++ b/SnipeitPS/Public/Set-SnipeitCompany.ps1
@@ -21,10 +21,10 @@ Remove current image
 Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key API Key for Snipeit.
 
 .EXAMPLE
 An example
@@ -32,8 +32,7 @@ An example
 .NOTES
 General notes
 #>
-function Set-SnipeitCompany()
-{
+function Set-SnipeitCompany() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Medium"
@@ -54,10 +53,10 @@ function Set-SnipeitCompany()
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
@@ -66,20 +65,34 @@ function Set-SnipeitCompany()
     }
 
     process{
-        foreach($company_id in $id){
+        foreach($company_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/companies/$company_id"
+                Api    = "/api/v1/companies/$company_id"
                 Method = $RequestType
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-            {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitCompany.ps1
+++ b/SnipeitPS/Public/Set-SnipeitCompany.ps1
@@ -17,6 +17,9 @@ Image file name and path for item
 .PARAMETER image_delete
 Remove current image
 
+.PARAMETER RequestType
+Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -48,6 +51,9 @@ function Set-SnipeitCompany()
 
         [switch]$image_delete=$false,
 
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -63,7 +69,7 @@ function Set-SnipeitCompany()
         foreach($company_id in $id){
             $Parameters = @{
                 Uri    = "$url/api/v1/companies/$company_id"
-                Method = 'Patch'
+                Method = $RequestType
                 Body   = $Values
                 Token  = $apiKey
             }

--- a/SnipeitPS/Public/Set-SnipeitComponent.ps1
+++ b/SnipeitPS/Public/Set-SnipeitComponent.ps1
@@ -32,6 +32,12 @@ Date accessory was purchased
 .PARAMETER purchase_cost
 Cost of item being purchased.
 
+.PARAMETER image
+Image file name and path for item
+
+.PARAMETER image_delete
+Remove current image
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -72,6 +78,11 @@ function Set-SnipeitComponent()
         [datetime]$purchase_date,
 
         [float]$purchase_cost,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitComponent.ps1
+++ b/SnipeitPS/Public/Set-SnipeitComponent.ps1
@@ -38,6 +38,9 @@ Image file name and path for item
 .PARAMETER image_delete
 Remove current image
 
+.PARAMETER RequestType
+Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -84,6 +87,9 @@ function Set-SnipeitComponent()
 
         [switch]$image_delete=$false,
 
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -104,7 +110,7 @@ function Set-SnipeitComponent()
         foreach($component_id in $id){
         $Parameters = @{
             Uri    = "$url/api/v1/components/$component_id"
-            Method = 'Patch'
+            Method = $RequestType
             Body   = $Values
             Token  = $apiKey
         }

--- a/SnipeitPS/Public/Set-SnipeitComponent.ps1
+++ b/SnipeitPS/Public/Set-SnipeitComponent.ps1
@@ -42,19 +42,17 @@ Remove current image
 Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key API Key for Snipeit.
 
 .EXAMPLE
-An example
+Set-SnipeitComponent -id 42 -qty 12
+Sets count of component with ID 42 to 12
 
-.NOTES
-General notes
 #>
-function Set-SnipeitComponent()
-{
+function Set-SnipeitComponent() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Medium"
@@ -90,10 +88,10 @@ function Set-SnipeitComponent()
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
     begin {
@@ -107,20 +105,35 @@ function Set-SnipeitComponent()
     }
 
     process {
-        foreach($component_id in $id){
+        foreach($component_id in $id) {
         $Parameters = @{
-            Uri    = "$url/api/v1/components/$component_id"
+            Api    = "/api/v1/components/$component_id"
             Method = $RequestType
             Body   = $Values
-            Token  = $apiKey
         }
 
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-        {
+        if ($PSBoundParameters.ContainsKey('apiKey')) {
+            Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyApiKey -apiKey $apikey
+        }
+
+        if ($PSBoundParameters.ContainsKey('url')) {
+            Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+            Set-SnipeitPSLegacyUrl -url $url
+        }
+
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
             $result = Invoke-SnipeitMethod @Parameters
         }
 
         $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitComponent.ps1
+++ b/SnipeitPS/Public/Set-SnipeitComponent.ps1
@@ -82,13 +82,11 @@ function Set-SnipeitComponent()
     begin {
         Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-        $values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-        if ($values['purchase_date']) {
-            $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")
+        if ($Values['purchase_date']) {
+            $Values['purchase_date'] = $Values['purchase_date'].ToString("yyyy-MM-dd")
         }
-
-        $Body = $values | ConvertTo-Json;
     }
 
     process {
@@ -96,7 +94,7 @@ function Set-SnipeitComponent()
         $Parameters = @{
             Uri    = "$url/api/v1/components/$component_id"
             Method = 'Patch'
-            Body   = $Body
+            Body   = $Values
             Token  = $apiKey
         }
 

--- a/SnipeitPS/Public/Set-SnipeitConsumable.ps1
+++ b/SnipeitPS/Public/Set-SnipeitConsumable.ps1
@@ -53,6 +53,9 @@ Image file name and path for item
 .PARAMETER image_delete
 Remove current image
 
+.PARAMETER RequestType
+Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -123,6 +126,9 @@ function Set-SnipeitConsumable()
 
         [switch]$image_delete=$false,
 
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -143,7 +149,7 @@ function Set-SnipeitConsumable()
         foreach($consumable_id in $id ){
             $Parameters = @{
                 Uri    = "$url/api/v1/consumables/$consumable_id"
-                Method = 'Put'
+                Method = $RequestType
                 Body   = $Values
                 Token  = $apiKey
             }

--- a/SnipeitPS/Public/Set-SnipeitConsumable.ps1
+++ b/SnipeitPS/Public/Set-SnipeitConsumable.ps1
@@ -57,10 +57,10 @@ Remove current image
 Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
 
 .EXAMPLE
@@ -69,8 +69,7 @@ Create consumable with stock count 20 , alert when stock is  5 or lower
 
 #>
 
-function Set-SnipeitConsumable()
-{
+function Set-SnipeitConsumable() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
@@ -129,10 +128,10 @@ function Set-SnipeitConsumable()
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
 
     )
@@ -146,20 +145,35 @@ function Set-SnipeitConsumable()
     }
 
     process {
-        foreach($consumable_id in $id ){
+        foreach($consumable_id in $id ) {
             $Parameters = @{
-                Uri    = "$url/api/v1/consumables/$consumable_id"
+                Api    = "/api/v1/consumables/$consumable_id"
                 Method = $RequestType
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-            {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
             }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
+        }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitConsumable.ps1
+++ b/SnipeitPS/Public/Set-SnipeitConsumable.ps1
@@ -126,7 +126,6 @@ function Set-SnipeitConsumable()
             $Values['purchase_date'] = $Values['purchase_date'].ToString("yyyy-MM-dd")
         }
 
-        $Body = $Values | ConvertTo-Json;
     }
 
     process {
@@ -134,7 +133,7 @@ function Set-SnipeitConsumable()
             $Parameters = @{
                 Uri    = "$url/api/v1/consumables/$consumable_id"
                 Method = 'Put'
-                Body   = $Body
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitConsumable.ps1
+++ b/SnipeitPS/Public/Set-SnipeitConsumable.ps1
@@ -47,6 +47,12 @@ Model number of the consumable in months
 .PARAMETER item_no
 Item number for the consumable
 
+.PARAMETER image
+Image file name and path for item
+
+.PARAMETER image_delete
+Remove current image
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -111,6 +117,11 @@ function Set-SnipeitConsumable()
 
         [parameter(mandatory = $false)]
         [string]$item_no,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitCustomField.ps1
+++ b/SnipeitPS/Public/Set-SnipeitCustomField.ps1
@@ -33,17 +33,16 @@
     Http request type to send Snipe IT system. Defaults to Put you could use Patch if needed.
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
     New-SnipeitCustomField -Name "AntivirusInstalled" -Format "BOOLEAN" -HelpText "Is AntiVirus installed on Asset"
 #>
 
-function Set-SnipeitCustomField()
-{
+function Set-SnipeitCustomField() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
@@ -75,10 +74,10 @@ function Set-SnipeitCustomField()
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Put",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
     begin {
@@ -93,18 +92,32 @@ function Set-SnipeitCustomField()
     process{
         foreach($field_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/fields/$field_id"
+                Api    = "/api/v1/fields/$field_id"
                 Method = $RequestType
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-            {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitCustomField.ps1
+++ b/SnipeitPS/Public/Set-SnipeitCustomField.ps1
@@ -82,9 +82,6 @@ function Set-SnipeitCustomField()
         }
 
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-        $Body = $Values | ConvertTo-Json;
-
     }
 
     process{
@@ -92,7 +89,7 @@ function Set-SnipeitCustomField()
             $Parameters = @{
                 Uri    = "$url/api/v1/fields/$field_id"
                 Method = 'Put'
-                Body   = $Body
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitCustomField.ps1
+++ b/SnipeitPS/Public/Set-SnipeitCustomField.ps1
@@ -29,6 +29,9 @@
     .PARAMETER help_text
     Any additional text you wish to display under the new form field to make it clearer what the gauges should be.
 
+    .PARAMETER RequestType
+    Http request type to send Snipe IT system. Defaults to Put you could use Patch if needed.
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -69,6 +72,9 @@ function Set-SnipeitCustomField()
 
         [string]$custom_format,
 
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Put",
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -88,7 +94,7 @@ function Set-SnipeitCustomField()
         foreach($field_id in $id) {
             $Parameters = @{
                 Uri    = "$url/api/v1/fields/$field_id"
-                Method = 'Put'
+                Method = $RequestType
                 Body   = $Values
                 Token  = $apiKey
             }

--- a/SnipeitPS/Public/Set-SnipeitDepartment.ps1
+++ b/SnipeitPS/Public/Set-SnipeitDepartment.ps1
@@ -26,6 +26,9 @@
     .PARAMETER image_delete
     Remove current image
 
+    .PARAMETER RequestType
+    Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -62,6 +65,9 @@ function Set-SnipeitDepartment() {
 
         [switch]$image_delete=$false,
 
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -78,7 +84,7 @@ function Set-SnipeitDepartment() {
         foreach ($department_id in $id) {
             $Parameters = @{
                 Uri    = "$url/api/v1/departments/$department_id"
-                Method = 'Put'
+                Method = $RequestType
                 Body   = $Values
                 Token  = $apiKey
             }

--- a/SnipeitPS/Public/Set-SnipeitDepartment.ps1
+++ b/SnipeitPS/Public/Set-SnipeitDepartment.ps1
@@ -30,10 +30,10 @@
     Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
     Set-SnipeitDepartment -id 4  -manager_id 3
@@ -68,10 +68,10 @@ function Set-SnipeitDepartment() {
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
@@ -83,17 +83,32 @@ function Set-SnipeitDepartment() {
     process {
         foreach ($department_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/departments/$department_id"
+                Api    = "/api/v1/departments/$department_id"
                 Method = $RequestType
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitDepartment.ps1
+++ b/SnipeitPS/Public/Set-SnipeitDepartment.ps1
@@ -61,8 +61,6 @@ function Set-SnipeitDepartment() {
     begin {
 
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-        $Body = $Values | ConvertTo-Json;
     }
 
     process {
@@ -70,7 +68,7 @@ function Set-SnipeitDepartment() {
             $Parameters = @{
                 Uri    = "$url/api/v1/departments/$department_id"
                 Method = 'Put'
-                Body   = $Body
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitDepartment.ps1
+++ b/SnipeitPS/Public/Set-SnipeitDepartment.ps1
@@ -20,6 +20,12 @@
     .PARAMETER manager_id
     ID number of manager
 
+    .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER image_delete
+    Remove current image
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -50,6 +56,11 @@ function Set-SnipeitDepartment() {
         [Nullable[System.Int32]]$manager_id,
 
         [string]$notes,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitInfo.ps1
+++ b/SnipeitPS/Public/Set-SnipeitInfo.ps1
@@ -1,14 +1,16 @@
 <#
     .SYNOPSIS
-    Sets authetication information
+    Sets authetication information. Deprecated, use Connect-SnipeitPS instead.
+
     .DESCRIPTION
-    Set apikey and url user to connect Snipe-It system
+    Deprecated combatibilty function that Set apikey and url user to connect Snipe-It system.
+    Please use Connect-SnipeitPS instead.
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    User's API Key for Snipeit.
 
     .EXAMPLE
     Set-SnipeitInfo -url $url -apiKey -Verbose
@@ -17,50 +19,18 @@ function Set-SnipeitInfo {
     [CmdletBinding()]
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseShouldProcessForStateChangingFunctions', '')]
     param (
+        [parameter(Mandatory=$true)]
         [Uri]$url,
-
+        [parameter(Mandatory=$true)]
         [String]$apiKey
     )
 
     BEGIN {
-        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
-        function Add-DefaultParameter {
-            param(
-                [Parameter(Mandatory = $true)]
-                [string]$Command,
 
-                [Parameter(Mandatory = $true)]
-                [string]$Parameter,
-
-                [Parameter(Mandatory = $true)]
-                $Value
-            )
-
-            PROCESS {
-                #Write-Verbose "[$($MyInvocation.MyCommand.Name)] Setting [$command : $parameter] = $value"
-
-                # Needs to set both global and module scope for the private functions:
-                # http://stackoverflow.com/questions/30427110/set-psdefaultparametersvalues-for-use-within-module-scope
-                $PSDefaultParameterValues["${command}:${parameter}"] = $Value
-                $global:PSDefaultParameterValues["${command}:${parameter}"] = $Value
-
-            }
-        }
-
-        $moduleCommands = Get-Command -Module SnipeitPS -CommandType Function
+        Write-Warning "Deprecated $($MyInvocation.InvocationName)  is still working, please use Connect-SnipeitPS instead."
     }
 
     PROCESS {
-        foreach ($command in $moduleCommands) {
-            $parameter = "url"
-            if ($url -and ($command.Parameters.Keys -contains $parameter)) {
-                Add-DefaultParameter -Command $command -Parameter $parameter -Value ($url.AbsoluteUri.TrimEnd('/'))
-            }
-
-            $parameter = "apiKey"
-            if ($apiKey -and ($command.Parameters.Keys -contains $parameter)) {
-                Add-DefaultParameter -Command $command -Parameter $parameter -Value $apiKey
-            }
-        }
+        Connect-SnipeitPS -Url $url -apiKey $apiKey
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitLicense.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLicense.ps1
@@ -133,19 +133,18 @@ function Set-SnipeitLicense() {
 
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-        if ($values['expiration_date']) {
-            $values['expiration_date'] = $values['expiration_date'].ToString("yyyy-MM-dd")
+        if ($Values['expiration_date']) {
+            $Values['expiration_date'] = $Values['expiration_date'].ToString("yyyy-MM-dd")
         }
 
-        if ($values['purchase_date']) {
-            $values['purchase_date'] = $values['purchase_date'].ToString("yyyy-MM-dd")
+        if ($Values['purchase_date']) {
+            $Values['purchase_date'] = $Values['purchase_date'].ToString("yyyy-MM-dd")
         }
 
-        if ($values['termination_date']) {
-            $values['termination_date'] = $values['termination_date'].ToString("yyyy-MM-dd")
+        if ($Values['termination_date']) {
+            $Values['termination_date'] = $Values['termination_date'].ToString("yyyy-MM-dd")
         }
 
-        $Body = $Values | ConvertTo-Json;
     }
 
     process {
@@ -153,7 +152,7 @@ function Set-SnipeitLicense() {
             $Parameters = @{
                 Uri    = "$url/api/v1/licenses/$license_id"
                 Method = 'PUT'
-                Body   = $Body
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitLicense.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLicense.ps1
@@ -59,6 +59,9 @@
     .PARAMETER termination_date
     Termination date for license.
 
+    .PARAMETER RequestType
+    Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -121,6 +124,9 @@ function Set-SnipeitLicense() {
 
         [datetime]$termination_date,
 
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -151,7 +157,7 @@ function Set-SnipeitLicense() {
         foreach($license_id in $id){
             $Parameters = @{
                 Uri    = "$url/api/v1/licenses/$license_id"
-                Method = 'PUT'
+                Method = $RequestType
                 Body   = $Values
                 Token  = $apiKey
             }

--- a/SnipeitPS/Public/Set-SnipeitLicense.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLicense.ps1
@@ -63,10 +63,10 @@
     Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
     Set-SnipeitLicence -name "License" -seats 3 -company_id 1
@@ -127,10 +127,10 @@ function Set-SnipeitLicense() {
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
@@ -154,19 +154,34 @@ function Set-SnipeitLicense() {
     }
 
     process {
-        foreach($license_id in $id){
+        foreach($license_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/licenses/$license_id"
+                Api    = "/api/v1/licenses/$license_id"
                 Method = $RequestType
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                 Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitLicenseSeat.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLicenseSeat.ps1
@@ -23,12 +23,16 @@
     User's API Key for Snipeit, can be set using Set-SnipeitInfo command
 
     .EXAMPLE
-    Set-SnipeitLicenceSeat -ID 1 -seat_id 1 -assigned_id 3  -Verbose
+    Set-SnipeitLicenceSeat -ID 1 -seat_id 1 -assigned_id 3
     Checkout licence to user id 3
 
     .EXAMPLE
-    Set-SnipeitLicenceSeat -ID 1 -seat_id 1 -asset_id 3  -Verbose
+    Set-SnipeitLicenceSeat -ID 1 -seat_id 1 -asset_id 3
     Checkout licence to asset id 3
+
+    .EXAMPLE
+    Set-SnipeitLicenceSeat -ID 1 -seat_id 1 -asset_id $null -assigned_id $null
+    Checkin licence seat id 1 of licence id 1
 
 #>
 function Set-SnipeitLicenseSeat()

--- a/SnipeitPS/Public/Set-SnipeitLicenseSeat.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLicenseSeat.ps1
@@ -16,6 +16,9 @@
     .PARAMETER note
     Notes about checkout
 
+    .PARAMETER RequestType
+    Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -58,6 +61,9 @@ function Set-SnipeitLicenseSeat()
 
         [string]$note,
 
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -73,7 +79,7 @@ function Set-SnipeitLicenseSeat()
         foreach($license_id in $id) {
             $Parameters = @{
                 Uri    = "$url/api/v1/licenses/$license_id/seats/$seat_id"
-                Method = 'Patch'
+                Method = $RequestType
                 Body   = $Values
                 Token  = $apiKey
             }

--- a/SnipeitPS/Public/Set-SnipeitLicenseSeat.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLicenseSeat.ps1
@@ -20,10 +20,10 @@
     Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
     Set-SnipeitLicenceSeat -ID 1 -seat_id 1 -assigned_id 3
@@ -38,8 +38,7 @@
     Checkin licence seat id 1 of licence id 1
 
 #>
-function Set-SnipeitLicenseSeat()
-{
+function Set-SnipeitLicenseSeat() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Medium"
@@ -64,10 +63,10 @@ function Set-SnipeitLicenseSeat()
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
@@ -78,18 +77,33 @@ function Set-SnipeitLicenseSeat()
     process{
         foreach($license_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/licenses/$license_id/seats/$seat_id"
+                Api    = "/api/v1/licenses/$license_id/seats/$seat_id"
                 Method = $RequestType
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?"))
-            {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             return $result
+        }
+
+        end {
+            # reset legacy sessions
+            if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+                Reset-SnipeitPSLegacyApi
+            }
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitLicenseSeat.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLicenseSeat.ps1
@@ -50,7 +50,9 @@ function Set-SnipeitLicenseSeat()
         [int]$seat_id,
 
         [Alias('assigned_id')]
+
         [Nullable[System.Int32]]$assigned_to,
+
 
         [Nullable[System.Int32]]$asset_id,
 
@@ -65,8 +67,6 @@ function Set-SnipeitLicenseSeat()
 
     begin{
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-        $Body = $Values | ConvertTo-Json;
     }
 
     process{
@@ -74,7 +74,7 @@ function Set-SnipeitLicenseSeat()
             $Parameters = @{
                 Uri    = "$url/api/v1/licenses/$license_id/seats/$seat_id"
                 Method = 'Patch'
-                Body   = $Body
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitLocation.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLocation.ps1
@@ -44,6 +44,12 @@
     .PARAMETER parent_id
     Parent location as id
 
+    .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER image_delete
+    Remove current image
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -87,6 +93,11 @@ function Set-SnipeitLocation() {
         [string]$ldap_ou,
 
         [Nullable[System.Int32]]$parent_id,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitLocation.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLocation.ps1
@@ -50,6 +50,9 @@
     .PARAMETER image_delete
     Remove current image
 
+    .PARAMETER RequestType
+    Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -99,6 +102,9 @@ function Set-SnipeitLocation() {
 
         [switch]$image_delete=$false,
 
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -116,7 +122,7 @@ function Set-SnipeitLocation() {
         foreach ($location_id in $id) {
             $Parameters = @{
                 Uri    = "$url/api/v1/locations/$location_id"
-                Method = 'PUT'
+                Method = $RequestType
                 Body   = $Values
                 Token  = $apiKey
             }

--- a/SnipeitPS/Public/Set-SnipeitLocation.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLocation.ps1
@@ -99,8 +99,6 @@ function Set-SnipeitLocation() {
         Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-
-        $Body = $Values | ConvertTo-Json;
     }
 
     process{
@@ -108,7 +106,7 @@ function Set-SnipeitLocation() {
             $Parameters = @{
                 Uri    = "$url/api/v1/locations/$location_id"
                 Method = 'PUT'
-                Body   = $Body
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitLocation.ps1
+++ b/SnipeitPS/Public/Set-SnipeitLocation.ps1
@@ -54,10 +54,10 @@
     Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
     Set-SnipeitLocation -id 123 -name "Some storage"  -parent_id 100
@@ -105,10 +105,10 @@ function Set-SnipeitLocation() {
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
@@ -121,17 +121,33 @@ function Set-SnipeitLocation() {
     process{
         foreach ($location_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/locations/$location_id"
+                Api    = "/api/v1/locations/$location_id"
                 Method = $RequestType
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitManufacturer.ps1
+++ b/SnipeitPS/Public/Set-SnipeitManufacturer.ps1
@@ -1,0 +1,78 @@
+<#
+    .SYNOPSIS
+    Add a new Manufacturer to Snipe-it asset system
+
+    .DESCRIPTION
+    Long description
+
+    .PARAMETER Name
+    Name of the Manufacturer
+
+    .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER image_delete
+    Remove current image
+
+    .PARAMETER RequestType
+    Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
+    .PARAMETER url
+    URL of Snipeit system, can be set using Set-SnipeitInfo command
+
+    .PARAMETER apiKey
+    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+
+    .EXAMPLE
+    New-SnipeitManufacturer -name "HP"
+#>
+
+function Set-SnipeitManufacturer()
+{
+    [CmdletBinding(
+        SupportsShouldProcess = $true,
+        ConfirmImpact = "Low"
+    )]
+
+    Param(
+        [parameter(mandatory = $true)]
+        [string]$Name,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
+
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
+        [parameter(mandatory = $true)]
+        [string]$url,
+
+        [parameter(mandatory = $true)]
+        [string]$apiKey
+    )
+
+    begin{
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+    }
+
+    process{
+        foreach ($manufacturer_id in $id) {
+            $Parameters = @{
+                Uri    = "$url/api/v1/manufacturers/$manufacturer_id"
+                Method = $RequestType
+                Body   = $Values
+                Token  = $apiKey
+            }
+
+            If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
+        }
+    }
+}

--- a/SnipeitPS/Public/Set-SnipeitManufacturer.ps1
+++ b/SnipeitPS/Public/Set-SnipeitManufacturer.ps1
@@ -18,17 +18,16 @@
     Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
     New-SnipeitManufacturer -name "HP"
 #>
 
-function Set-SnipeitManufacturer()
-{
+function Set-SnipeitManufacturer() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
@@ -46,10 +45,10 @@ function Set-SnipeitManufacturer()
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
@@ -62,17 +61,33 @@ function Set-SnipeitManufacturer()
     process{
         foreach ($manufacturer_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/manufacturers/$manufacturer_id"
+                Api    = "/api/v1/manufacturers/$manufacturer_id"
                 Method = $RequestType
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitModel.ps1
+++ b/SnipeitPS/Public/Set-SnipeitModel.ps1
@@ -69,14 +69,13 @@ function Set-SnipeitModel() {
 
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
-        $Body = $Values | ConvertTo-Json;
     }
     process {
         foreach ($model_id in $id) {
             $Parameters = @{
                 Uri    = "$url/api/v1/models/$model_id"
                 Method = 'put'
-                Body   = $Body
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitModel.ps1
+++ b/SnipeitPS/Public/Set-SnipeitModel.ps1
@@ -23,6 +23,12 @@
     .PARAMETER fieldset_id
     Fieldset ID that the asset uses (Custom fields)
 
+    .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER image_delete
+    Remove current image
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -56,6 +62,11 @@ function Set-SnipeitModel() {
 
         [Alias("fieldset_id")]
         [Nullable[System.Int32]]$custom_fieldset_id,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitModel.ps1
+++ b/SnipeitPS/Public/Set-SnipeitModel.ps1
@@ -29,6 +29,9 @@
     .PARAMETER image_delete
     Remove current image
 
+    .PARAMETER RequestType
+    Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -68,6 +71,9 @@ function Set-SnipeitModel() {
 
         [switch]$image_delete=$false,
 
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -85,7 +91,7 @@ function Set-SnipeitModel() {
         foreach ($model_id in $id) {
             $Parameters = @{
                 Uri    = "$url/api/v1/models/$model_id"
-                Method = 'put'
+                Method = $RequestType
                 Body   = $Values
                 Token  = $apiKey
             }

--- a/SnipeitPS/Public/Set-SnipeitModel.ps1
+++ b/SnipeitPS/Public/Set-SnipeitModel.ps1
@@ -33,10 +33,10 @@
     Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
     New-SnipeitModel -name "DL380" -manufacturer_id 2 -fieldset_id 2 -category_id 1
@@ -74,10 +74,10 @@ function Set-SnipeitModel() {
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
@@ -90,17 +90,33 @@ function Set-SnipeitModel() {
     process {
         foreach ($model_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/models/$model_id"
+                Api    = "/api/v1/models/$model_id"
                 Method = $RequestType
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitStatus.ps1
+++ b/SnipeitPS/Public/Set-SnipeitStatus.ps1
@@ -19,10 +19,10 @@ Hex code showing what color the status label should be on the pie chart in the d
 Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
 .PARAMETER url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
 .PARAMETER apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
 .EXAMPLE
 Get-SnipeitStatus -search  "Ready to Deploy"
@@ -32,8 +32,7 @@ Set-SnipeitStatus -id 3 -name 'Waiting for arrival' -type pending
 
 #>
 
-function Set-SnipeitStatus()
-{
+function Set-SnipeitStatus() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Medium"
@@ -59,10 +58,10 @@ function Set-SnipeitStatus()
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
@@ -73,16 +72,32 @@ function Set-SnipeitStatus()
     process {
         foreach($status_id in $id) {
             $Parameters = @{
-                Uri           = "$url/api/v1/statuslabels/$status_id"
+                Api           = "/api/v1/statuslabels/$status_id"
                 Method        = $RequestType
                 Body          = $Values
-                Token         = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
             $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitStatus.ps1
+++ b/SnipeitPS/Public/Set-SnipeitStatus.ps1
@@ -15,6 +15,9 @@ Hex code showing what color the status label should be on the pie chart in the d
 .PARAMETER default_label
 1 or 0 - determine whether it should be bubbled up to the top of the list of available statuses
 
+.PARAMETER RequestType
+Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
 .PARAMETER url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -53,6 +56,9 @@ function Set-SnipeitStatus()
 
         [bool]$default_label,
 
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
         [parameter(mandatory = $true)]
         [string]$url,
 
@@ -68,7 +74,7 @@ function Set-SnipeitStatus()
         foreach($status_id in $id) {
             $Parameters = @{
                 Uri           = "$url/api/v1/statuslabels/$status_id"
-                Method        = 'Put'
+                Method        = $RequestType
                 Body          = $Values
                 Token         = $apiKey
             }

--- a/SnipeitPS/Public/Set-SnipeitStatus.ps1
+++ b/SnipeitPS/Public/Set-SnipeitStatus.ps1
@@ -62,7 +62,6 @@ function Set-SnipeitStatus()
 
     begin {
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
-        $Body = $Values | ConvertTo-Json
     }
 
     process {
@@ -70,7 +69,7 @@ function Set-SnipeitStatus()
             $Parameters = @{
                 Uri           = "$url/api/v1/statuslabels/$status_id"
                 Method        = 'Put'
-                Body          = $Body
+                Body          = $Values
                 Token         = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitSupplier.ps1
+++ b/SnipeitPS/Public/Set-SnipeitSupplier.ps1
@@ -51,10 +51,10 @@
     Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. Users API Key for Snipeit.
 
     .EXAMPLE
     New-SnipeitDepartment -name "Department1" -company_id 1 -localtion_id 1 -manager_id 3
@@ -101,10 +101,10 @@ function Set-SnipeitSupplier() {
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
 
@@ -117,17 +117,33 @@ function Set-SnipeitSupplier() {
     process {
         foreach ($supplier_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/suppliers/$supplier_id"
+                Api    = "/api/v1/suppliers/$supplier_id"
                 Method = $RequestType
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Set-SnipeitSupplier.ps1
+++ b/SnipeitPS/Public/Set-SnipeitSupplier.ps1
@@ -1,0 +1,134 @@
+<#
+    .SYNOPSIS
+    Modify the supplier
+
+    .DESCRIPTION
+    Modifieds the supplier on Snipe-It system
+
+    .PARAMETER name
+    Suppiers Name
+
+    .PARAMETER address
+    Address line 1 of supplier
+
+    .PARAMETER address2
+    Address line 1 of supplier
+
+    .PARAMETER city
+    City
+
+    .PARAMETER state
+    State
+
+    .PARAMETER country
+    Country
+
+    .PARAMETER zip
+    Zip code
+
+    .PARAMETER phone
+    Phone number
+
+    .PARAMETER fax
+    Fax number
+
+    .PARAMETER email
+    Email address
+
+    .PARAMETER contact
+    Contact person
+
+    .PARAMETER notes
+    Email address
+
+    .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER image_delete
+    Remove current image
+
+    .PARAMETER RequestType
+    Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
+    .PARAMETER url
+    URL of Snipeit system, can be set using Set-SnipeitInfo command
+
+    .PARAMETER apiKey
+    Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+
+    .EXAMPLE
+    New-SnipeitDepartment -name "Department1" -company_id 1 -localtion_id 1 -manager_id 3
+
+#>
+
+function Set-SnipeitSupplier() {
+    [CmdletBinding(
+        SupportsShouldProcess = $true,
+        ConfirmImpact = "Low"
+    )]
+
+    Param(
+        [parameter(mandatory = $true)]
+        [string]$name,
+
+        [string]$address,
+
+        [string]$address2,
+
+        [string]$city,
+
+        [string]$state,
+
+        [string]$country,
+
+        [string]$zip,
+
+        [string]$phone,
+
+        [string]$fax,
+
+        [string]$email,
+
+        [string]$contact,
+
+        [string]$notes,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete,
+
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
+
+        [parameter(mandatory = $true)]
+        [string]$url,
+
+        [parameter(mandatory = $true)]
+        [string]$apiKey
+    )
+
+    begin {
+        Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
+
+        $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+
+    }
+    process {
+        foreach ($supplier_id in $id) {
+            $Parameters = @{
+                Uri    = "$url/api/v1/suppliers/$supplier_id"
+                Method = $RequestType
+                Body   = $Values
+                Token  = $apiKey
+            }
+
+            If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+                $result = Invoke-SnipeitMethod @Parameters
+            }
+
+            $result
+        }
+    }
+}
+

--- a/SnipeitPS/Public/Set-SnipeitUser.ps1
+++ b/SnipeitPS/Public/Set-SnipeitUser.ps1
@@ -53,6 +53,12 @@
     .PARAMETER ldap_import
     Mark user as import from ldap
 
+    .PARAMETER image
+    Image file name and path for item
+
+    .PARAMETER image_delete
+    Remove current image
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -106,6 +112,11 @@ function Set-SnipeitUser() {
         [bool]$activated,
 
         [string]$notes,
+
+        [ValidateScript({Test-Path $_})]
+        [string]$image,
+
+        [switch]$image_delete=$false,
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitUser.ps1
+++ b/SnipeitPS/Public/Set-SnipeitUser.ps1
@@ -92,7 +92,7 @@ function Set-SnipeitUser() {
         [string]$last_name,
 
         [ValidateLength(1,256)]
-        [string]$userName,
+        [string]$username,
 
         [string]$jobtitle,
 

--- a/SnipeitPS/Public/Set-SnipeitUser.ps1
+++ b/SnipeitPS/Public/Set-SnipeitUser.ps1
@@ -122,7 +122,6 @@ function Set-SnipeitUser() {
             $Values['password_confirmation'] = $password
         }
 
-        $Body = $Values | ConvertTo-Json;
     }
 
     process{
@@ -130,7 +129,7 @@ function Set-SnipeitUser() {
             $Parameters = @{
                 Uri    = "$url/api/v1/users/$user_id"
                 Method = 'PATCH'
-                Body   = $Body
+                Body   = $Values
                 Token  = $apiKey
             }
 

--- a/SnipeitPS/Public/Set-SnipeitUser.ps1
+++ b/SnipeitPS/Public/Set-SnipeitUser.ps1
@@ -59,6 +59,9 @@
     .PARAMETER image_delete
     Remove current image
 
+    .PARAMETER RequestType
+    Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
+
     .PARAMETER url
     URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -117,6 +120,9 @@ function Set-SnipeitUser() {
         [string]$image,
 
         [switch]$image_delete=$false,
+
+        [ValidateSet("Put","Patch")]
+        [string]$RequestType = "Patch",
 
         [parameter(mandatory = $true)]
         [string]$url,

--- a/SnipeitPS/Public/Set-SnipeitUser.ps1
+++ b/SnipeitPS/Public/Set-SnipeitUser.ps1
@@ -63,10 +63,10 @@
     Http request type to send Snipe IT system. Defaults to Patch you could use Put if needed.
 
     .PARAMETER url
-    URL of Snipeit system, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. URL of Snipeit system.
 
     .PARAMETER apiKey
-    User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+    Deprecated parameter, please use Connect-SnipeitPS instead. User's API Key for Snipeit.
 
     .EXAMPLE
     Update-SnipeitUser -id 3 -fist_name It -lastname Snipe -username snipeit -activated $false -company_id 1 -location_id 1 -department_id 1
@@ -124,10 +124,10 @@ function Set-SnipeitUser() {
         [ValidateSet("Put","Patch")]
         [string]$RequestType = "Patch",
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$url,
 
-        [parameter(mandatory = $true)]
+        [parameter(mandatory = $false)]
         [string]$apiKey
     )
     begin{
@@ -144,17 +144,33 @@ function Set-SnipeitUser() {
     process{
         foreach($user_id in $id) {
             $Parameters = @{
-                Uri    = "$url/api/v1/users/$user_id"
+                Api    = "/api/v1/users/$user_id"
                 Method = 'PATCH'
                 Body   = $Values
-                Token  = $apiKey
             }
 
-            If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            if ($PSBoundParameters.ContainsKey('apiKey')) {
+                Write-Warning "-apiKey parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyApiKey -apiKey $apikey
+            }
+
+            if ($PSBoundParameters.ContainsKey('url')) {
+                Write-Warning "-url parameter is deprecated, please use Connect-SnipeitPS instead."
+                Set-SnipeitPSLegacyUrl -url $url
+            }
+
+            if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
                 $result = Invoke-SnipeitMethod @Parameters
             }
 
             $result
+        }
+    }
+
+    end {
+        # reset legacy sessions
+        if ($PSBoundParameters.ContainsKey('url') -or $PSBoundParameters.ContainsKey('apiKey')) {
+            Reset-SnipeitPSLegacyApi
         }
     }
 }

--- a/SnipeitPS/Public/Update-SnipeitAlias.ps1
+++ b/SnipeitPS/Public/Update-SnipeitAlias.ps1
@@ -15,8 +15,7 @@ Replaces old command from file "your-script.ps1" and creates new script "new-scr
 After testing new file you can replace old file with new.
 
 #>
-function Update-SnipeitAlias()
-{
+function Update-SnipeitAlias() {
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = "Low"
@@ -34,8 +33,8 @@ function Update-SnipeitAlias()
 
     }
     process {
-        If ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
-            ForEach ($st in $String){
+        if ($PSCmdlet.ShouldProcess("ShouldProcess?")) {
+            ForEach ($st in $String) {
                 $result = $st
                 ForEach ($key in $SnipeitAliases.Keys ) {
                     #Write-Verbose "Replacing $key with $($SnipeitAliases[$key])"

--- a/SnipeitPS/SnipeitPS.psd1
+++ b/SnipeitPS/SnipeitPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'SnipeitPS'
 
 # Version number of this module.
-ModuleVersion = '1.8'
+ModuleVersion = '1.9'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/SnipeitPS/SnipeitPS.psd1
+++ b/SnipeitPS/SnipeitPS.psd1
@@ -135,6 +135,7 @@ FunctionsToExport = @(
         'Set-SnipeitLicense',
         'Set-SnipeitLicenseSeat',
         'Set-SnipeitLocation',
+        'Set-SnipeitManufacturer',
         'Set-SnipeitModel',
         'Set-SnipeitStatus',
         'Set-SnipeitUser',

--- a/SnipeitPS/SnipeitPS.psd1
+++ b/SnipeitPS/SnipeitPS.psd1
@@ -70,6 +70,7 @@ PowerShellVersion = '5.1'
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
+        'Connect-SnipeitPS',
         'Get-SnipeitAccessory',
         'Get-SnipeitAccessoryOwner',
         'Get-SnipeitActivity',

--- a/SnipeitPS/SnipeitPS.psd1
+++ b/SnipeitPS/SnipeitPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'SnipeitPS'
 
 # Version number of this module.
-ModuleVersion = '1.9'
+ModuleVersion = '1.10'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/SnipeitPS/SnipeitPS.psd1
+++ b/SnipeitPS/SnipeitPS.psd1
@@ -104,6 +104,7 @@ FunctionsToExport = @(
         'New-SnipeitLocation',
         'New-SnipeitManufacturer',
         'New-SnipeitModel',
+        'New-SnipeitSupplier',
         'New-SnipeitUser',
         'Remove-SnipeitAccessory',
         'Remove-SnipeitAsset',
@@ -118,6 +119,7 @@ FunctionsToExport = @(
         'Remove-SnipeitLocation',
         'Remove-SnipeitManufacturer',
         'Remove-SnipeitModel',
+        'Remove-SnipeitSupplier',
         'Remove-SnipeitUser',
         'Reset-SnipeitAccessoryOwner',
         'Reset-SnipeitAssetOwner',
@@ -138,6 +140,7 @@ FunctionsToExport = @(
         'Set-SnipeitManufacturer',
         'Set-SnipeitModel',
         'Set-SnipeitStatus',
+        'Set-SnipeitSupplier',
         'Set-SnipeitUser',
         'Update-SnipeitAlias'
 )

--- a/SnipeitPS/SnipeitPS.psd1
+++ b/SnipeitPS/SnipeitPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'SnipeitPS'
 
 # Version number of this module.
-ModuleVersion = '1.7'
+ModuleVersion = '1.8'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/SnipeitPS/SnipeitPS.psm1
+++ b/SnipeitPS/SnipeitPS.psm1
@@ -5,14 +5,22 @@ Powershell API for Snipeit Asset Management
 $scriptRoot = $PSScriptRoot + '\Public'
 
 Get-ChildItem $scriptRoot *.ps1 | ForEach-Object {
-    Import-Module $_.FullName
+    . $_.FullName
 }
 
 $scriptRoot = $PSScriptRoot + '\Private'
 
 Get-ChildItem $scriptRoot *.ps1 | ForEach-Object {
-    Import-Module $_.FullName
+    . $_.FullName
 }
 
 #Create unprefixed aliases
 Set-SnipeitAlias
+
+#Session variable for storing current session information
+$SnipeitPSSession = [ordered]@{
+    'url' = $null
+    'apiKey' = $null
+}
+New-Variable -Name SnipeitPSSession  -Value $SnipeitPSSession -Scope Script -Force
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
     secure: UdM6qhf5B0G8liHhUrwWERCZr44iSqmg4jUq0lwlTjZs4KyeoiwnBzdej0phqIAm
   PShell: '5'
 
-version: 1.8.{build}
+version: 1.9.{build}
 
 # Don't rebuild when I tag a release on GitHub
 skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
     secure: UdM6qhf5B0G8liHhUrwWERCZr44iSqmg4jUq0lwlTjZs4KyeoiwnBzdej0phqIAm
   PShell: '5'
 
-version: 1.7.{build}
+version: 1.8.{build}
 
 # Don't rebuild when I tag a release on GitHub
 skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
     secure: UdM6qhf5B0G8liHhUrwWERCZr44iSqmg4jUq0lwlTjZs4KyeoiwnBzdej0phqIAm
   PShell: '5'
 
-version: 1.9.{build}
+version: 1.10.{build}
 
 # Don't rebuild when I tag a release on GitHub
 skip_tags: true

--- a/docs/Connect-SnipeitPS.md
+++ b/docs/Connect-SnipeitPS.md
@@ -1,0 +1,137 @@
+﻿---
+external help file: SnipeitPS-help.xml
+Module Name: snipeitps
+online version:
+schema: 2.0.0
+---
+
+# Connect-SnipeitPS
+
+## SYNOPSIS
+Sets authetication information
+
+## SYNTAX
+
+### Connect with url and apikey (Default)
+```
+Connect-SnipeitPS -url <Uri> -apiKey <String> [<CommonParameters>]
+```
+
+### Connect with url and secure apikey
+```
+Connect-SnipeitPS -url <Uri> -secureApiKey <SecureString> [<CommonParameters>]
+```
+
+### Connect with credential
+```
+Connect-SnipeitPS -siteCred <PSCredential> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Sets apikey and url to connect Snipe-It system.
+Based on Set-SnipeitInfo command, what is now just combatipility wrapper
+and calls Connect-SnipeitPS
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Connect-SnipeitPS -Url $url -apiKey $myapikey
+Connect to  Snipe it  api.
+```
+
+### EXAMPLE 2
+```
+Connect-SnipeitPS -Url $url -SecureApiKey $myapikey
+Connects to Snipe it api with apikey stored to securestring
+```
+
+### EXAMPLE 3
+```
+Connect-SnipeitPS -siteCred (Get-Credential -message "Use site url as username and apikey as password")
+Connect to Snipe It with PSCredential object.
+To use saved creadentials yu can use export-clixml and import-clixml commandlets.
+```
+
+### EXAMPLE 4
+```
+Build credential with apikey value from secret vault (Microsoft.PowerShell.SecretManagement)
+$siteurl = "https://mysnipeitsite.url"
+$apikey = Get-SecretInfo -Name SnipeItApiKey
+$siteCred = New-Object -Type PSCredential -Argumentlist $siteurl,$spikey
+Connect-SnipeitPS -siteCred $siteCred
+```
+
+## PARAMETERS
+
+### -apiKey
+User's API Key for Snipeit.
+
+```yaml
+Type: String
+Parameter Sets: Connect with url and apikey
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -secureApiKey
+Snipe it Api key as securestring
+
+```yaml
+Type: SecureString
+Parameter Sets: Connect with url and secure apikey
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -siteCred
+PSCredential where username shoul be snipe it url and password should be
+snipe it apikey.
+
+```yaml
+Type: PSCredential
+Parameter Sets: Connect with credential
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -url
+URL of Snipeit system.
+
+```yaml
+Type: Uri
+Parameter Sets: Connect with url and apikey, Connect with url and secure apikey
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/Get-SnipeitAccessory.md
+++ b/docs/Get-SnipeitAccessory.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -16,17 +16,17 @@ Gets a list of Snipe-it Accessories
 ```
 Get-SnipeitAccessory [-search <String>] [-company_id <Int32>] [-category_id <Int32>] [-manufacturer_id <Int32>]
  [-supplier_id <Int32>] [-sort <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all]
- -url <String> -apiKey <String> [<CommonParameters>]
+ [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get by ID
 ```
-Get-SnipeitAccessory [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitAccessory [-id <Int32>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Accessories checked out to user id
 ```
-Get-SnipeitAccessory [-user_id <Int32>] [-all] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitAccessory [-user_id <Int32>] [-all] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -68,14 +68,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -235,14 +236,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitAccessory.md
+++ b/docs/Get-SnipeitAccessory.md
@@ -24,6 +24,11 @@ Get-SnipeitAccessory [-search <String>] [-company_id <Int32>] [-category_id <Int
 Get-SnipeitAccessory [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
 ```
 
+### Accessories checked out to user id
+```
+Get-SnipeitAccessory [-user_id <Int32>] [-all] -url <String> -apiKey <String> [<CommonParameters>]
+```
+
 ## DESCRIPTION
 Gets a list of Snipe-it Accessories
 
@@ -39,6 +44,12 @@ Get-SnipeitAccessory -search Keyboard
 Get-SnipeitAccessory -id 1
 ```
 
+### EXAMPLE 3
+```
+Get-SnipeitAccessory -user_id 1
+Get accessories checked out to user ID 1
+```
+
 ## PARAMETERS
 
 ### -all
@@ -46,7 +57,7 @@ A return all results, works with -offset and other parameters
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Search
+Parameter Sets: Search, Accessories checked out to user id
 Aliases:
 
 Required: False
@@ -234,6 +245,21 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -user_id
+{{ Fill user_id Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: Accessories checked out to user id
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Get-SnipeitAccessoryOwner.md
+++ b/docs/Get-SnipeitAccessoryOwner.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Get list of checked out accessories
 ## SYNTAX
 
 ```
-Get-SnipeitAccessoryOwner [-id] <Int32> [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
+Get-SnipeitAccessoryOwner [-id] <Int32> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -30,14 +30,15 @@ Get-SnipeitAccessoryOwner -id 1
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -60,14 +61,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitActivity.md
+++ b/docs/Get-SnipeitActivity.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,7 +15,7 @@ Gets and search Snipe-it Activity history
 ```
 Get-SnipeitActivity [[-search] <String>] [[-target_type] <String>] [[-target_id] <Int32>]
  [[-item_type] <String>] [[-item_id] <Int32>] [[-action_type] <String>] [[-limit] <Int32>] [[-offset] <Int32>]
- [-all] [-url] <String> [-apiKey] <String> [<CommonParameters>]
+ [-all] [[-url] <String>] [[-apiKey] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -67,14 +67,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 10
 Default value: None
 Accept pipeline input: False
@@ -189,14 +190,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 9
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitAsset.md
+++ b/docs/Get-SnipeitAsset.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -17,46 +17,46 @@ Gets a list of Snipe-it Assets or specific asset
 Get-SnipeitAsset [-search <String>] [-order_number <String>] [-model_id <Int32>] [-category_id <Int32>]
  [-manufacturer_id <Int32>] [-company_id <Int32>] [-location_id <Int32>] [-depreciation_id <Int32>]
  [-requestable <Boolean>] [-status <String>] [-status_id <Int32>] [-sort <String>] [-order <String>]
- [-limit <Int32>] [-offset <Int32>] [-all] -url <String> -apiKey <String> [<CommonParameters>]
+ [-limit <Int32>] [-offset <Int32>] [-all] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with id
 ```
-Get-SnipeitAsset [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitAsset [-id <Int32>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with asset tag
 ```
-Get-SnipeitAsset [-asset_tag <String>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitAsset [-asset_tag <String>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with serial
 ```
-Get-SnipeitAsset [-serial <String>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitAsset [-serial <String>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Assets due auditing soon
 ```
 Get-SnipeitAsset [-audit_due] [-sort <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all]
- -url <String> -apiKey <String> [<CommonParameters>]
+ [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Assets overdue for auditing
 ```
 Get-SnipeitAsset [-audit_overdue] [-sort <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all]
- -url <String> -apiKey <String> [<CommonParameters>]
+ [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Assets checked out to user id
 ```
 Get-SnipeitAsset [-user_id <Int32>] [-sort <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>]
- [-all] -url <String> -apiKey <String> [<CommonParameters>]
+ [-all] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Assets with component id
 ```
 Get-SnipeitAsset [-component_id <Int32>] [-sort <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>]
- [-all] -url <String> -apiKey <String> [<CommonParameters>]
+ [-all] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -66,7 +66,7 @@ Get-SnipeitAsset [-component_id <Int32>] [-sort <String>] [-order <String>] [-li
 
 ### EXAMPLE 1
 ```
-Get-SnipeitAsset -all -url "https://assets.example.com"-token "token..."
+Get-SnipeitAsset -all
 Returens all assets
 ```
 
@@ -136,14 +136,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -468,14 +469,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitAsset.md
+++ b/docs/Get-SnipeitAsset.md
@@ -47,6 +47,18 @@ Get-SnipeitAsset [-audit_overdue] [-sort <String>] [-order <String>] [-limit <In
  -url <String> -apiKey <String> [<CommonParameters>]
 ```
 
+### Assets checked out to user id
+```
+Get-SnipeitAsset [-user_id <Int32>] [-sort <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>]
+ [-all] -url <String> -apiKey <String> [<CommonParameters>]
+```
+
+### Assets with component id
+```
+Get-SnipeitAsset [-component_id <Int32>] [-sort <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>]
+ [-all] -url <String> -apiKey <String> [<CommonParameters>]
+```
+
 ## DESCRIPTION
 {{ Fill in the Description }}
 
@@ -54,22 +66,56 @@ Get-SnipeitAsset [-audit_overdue] [-sort <String>] [-order <String>] [-limit <In
 
 ### EXAMPLE 1
 ```
-Get-SnipeitAsset -url "https://assets.example.com"-token "token..."
+Get-SnipeitAsset -all -url "https://assets.example.com"-token "token..."
+Returens all assets
 ```
 
 ### EXAMPLE 2
 ```
-Get-SnipeitAsset -search "myMachine"-url "https://assets.example.com"-token "token..."
+Get-SnipeitAsset -search "myMachine"
+Search for specific asset
 ```
 
 ### EXAMPLE 3
 ```
-Get-SnipeitAsset -search "myMachine"-url "https://assets.example.com"-token "token..."
+Get-SnipeitAsset -id 3
+Get asset with id number 3
 ```
 
 ### EXAMPLE 4
 ```
-Get-SnipeitAsset -asset_tag "myAssetTag"-url "https://assets.example.com"-token "token..."
+Get-SnipeitAsset -asset_tag snipe0003
+Get asset with asset tag snipe00033
+```
+
+### EXAMPLE 5
+```
+Get-SnipeitAsset -serial 1234
+Get asset with searial number 1234
+```
+
+### EXAMPLE 6
+```
+Get-SnipeitAsser -audit_due
+Get Assets due auditing soon
+```
+
+### EXAMPLE 7
+```
+Get-SnipeitAsser -audit_overdue
+Get Assets overdue for auditing
+```
+
+### EXAMPLE 8
+```
+Get-AnipeitAsset -user_id 4
+Get Assets checked out to user id 4
+```
+
+### EXAMPLE 9
+```
+Get-SnipeitAsset -component_id 5
+Get Assets with component id 5
 ```
 
 ## PARAMETERS
@@ -79,7 +125,7 @@ A return all results, works with -offset and other parameters
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Search, Assets due auditing soon, Assets overdue for auditing
+Parameter Sets: Search, Assets due auditing soon, Assets overdue for auditing, Assets checked out to user id, Assets with component id
 Aliases:
 
 Required: False
@@ -179,6 +225,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -component_id
+{{ Fill component_id Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: Assets with component id
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -depreciation_id
 {{ Fill depreciation_id Description }}
 
@@ -216,7 +277,7 @@ Defines batch size for -all
 
 ```yaml
 Type: Int32
-Parameter Sets: Search, Assets due auditing soon, Assets overdue for auditing
+Parameter Sets: Search, Assets due auditing soon, Assets overdue for auditing, Assets checked out to user id, Assets with component id
 Aliases:
 
 Required: False
@@ -276,7 +337,7 @@ Offset to use
 
 ```yaml
 Type: Int32
-Parameter Sets: Search, Assets due auditing soon, Assets overdue for auditing
+Parameter Sets: Search, Assets due auditing soon, Assets overdue for auditing, Assets checked out to user id, Assets with component id
 Aliases:
 
 Required: False
@@ -291,7 +352,7 @@ Specify the order (asc or desc) you wish to order by on your sort column
 
 ```yaml
 Type: String
-Parameter Sets: Search, Assets due auditing soon, Assets overdue for auditing
+Parameter Sets: Search, Assets due auditing soon, Assets overdue for auditing, Assets checked out to user id, Assets with component id
 Aliases:
 
 Required: False
@@ -366,7 +427,7 @@ Specify the column name you wish to sort by
 
 ```yaml
 Type: String
-Parameter Sets: Search, Assets due auditing soon, Assets overdue for auditing
+Parameter Sets: Search, Assets due auditing soon, Assets overdue for auditing, Assets checked out to user id, Assets with component id
 Aliases:
 
 Required: False
@@ -417,6 +478,21 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -user_id
+{{ Fill user_id Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: Assets checked out to user id
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Get-SnipeitAssetMaintenance.md
+++ b/docs/Get-SnipeitAssetMaintenance.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,7 +14,7 @@ Lists Snipe-it Assets Maintenances
 
 ```
 Get-SnipeitAssetMaintenance [[-search] <String>] [[-asset_id] <Int32>] [[-sort] <String>] [[-order] <String>]
- [[-limit] <Int32>] [-all] [[-offset] <Int32>] [-url] <String> [-apiKey] <String> [<CommonParameters>]
+ [[-limit] <Int32>] [-all] [[-offset] <Int32>] [[-url] <String>] [[-apiKey] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -24,17 +24,17 @@ Get-SnipeitAssetMaintenance [[-search] <String>] [[-asset_id] <Int32>] [[-sort] 
 
 ### EXAMPLE 1
 ```
-Get-SnipeitAssetMaintenances -url "https://assets.example.com" -token "token..."
+Get-SnipeitAssetMaintenances
 ```
 
 ### EXAMPLE 2
 ```
-Get-SnipeitAssetMaintenances -search "myMachine" -url "https://assets.example.com" -token "token..."
+Get-SnipeitAssetMaintenances -search "myMachine"
 ```
 
 ### EXAMPLE 3
 ```
-Get-SnipeitAssetMaintenances -search "myMachine" -url "https://assets.example.com" -token "token..."
+Get-SnipeitAssetMaintenances -search "myMachine"
 ```
 
 ## PARAMETERS
@@ -55,14 +55,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 8
 Default value: None
 Accept pipeline input: False
@@ -162,14 +163,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 7
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitCategory.md
+++ b/docs/Get-SnipeitCategory.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,12 +15,12 @@ Gets a list of Snipe-it Categories
 ### Search (Default)
 ```
 Get-SnipeitCategory [-search <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all]
- -url <String> -apiKey <String> [<CommonParameters>]
+ [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with ID
 ```
-Get-SnipeitCategory [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitCategory [-id <Int32>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -56,14 +56,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -148,14 +149,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-Url of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Url of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitCompany.md
+++ b/docs/Get-SnipeitCompany.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,13 +14,13 @@ Gets a list of Snipe-it Companies
 
 ### Search (Default)
 ```
-Get-SnipeitCompany [-search <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all] -url <String>
- -apiKey <String> [<CommonParameters>]
+Get-SnipeitCompany [-search <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all]
+ [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with ID
 ```
-Get-SnipeitCompany [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitCompany [-id <Int32>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -58,14 +58,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -150,14 +151,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitComponent.md
+++ b/docs/Get-SnipeitComponent.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,13 +15,13 @@ Gets a list of Snipe-it Components
 ### Search (Default)
 ```
 Get-SnipeitComponent [-search <String>] [-category_id <Int32>] [-company_id <Int32>] [-location_id <Int32>]
- [-order <String>] [-sort <String>] [-limit <Int32>] [-offset <Int32>] [-all] -url <String> -apiKey <String>
- [<CommonParameters>]
+ [-order <String>] [-sort <String>] [-limit <Int32>] [-offset <Int32>] [-all] [-url <String>]
+ [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with ID
 ```
-Get-SnipeitComponent [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitComponent [-id <Int32>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -65,14 +65,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -217,14 +218,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system,can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitConsumable.md
+++ b/docs/Get-SnipeitConsumable.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -16,12 +16,12 @@ Gets a list of Snipe-it consumables
 ```
 Get-SnipeitConsumable [-search <String>] [-category_id <Int32>] [-company_id <Int32>]
  [-manufacturer_id <Int32>] [-location_id <Int32>] [-order <String>] [-sort <String>] [-expand]
- [-limit <Int32>] [-offset <Int32>] [-all] -url <String> -apiKey <String> [<CommonParameters>]
+ [-limit <Int32>] [-offset <Int32>] [-all] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with ID
 ```
-Get-SnipeitConsumable [-id <Int32[]>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitConsumable [-id <Int32[]>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -65,14 +65,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -247,14 +248,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system,can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitCustomField.md
+++ b/docs/Get-SnipeitCustomField.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Returns specific Snipe-IT custom field or a list of all custom field
 ## SYNTAX
 
 ```
-Get-SnipeitCustomField [[-id] <Int32>] [-url] <String> [-apiKey] <String> [<CommonParameters>]
+Get-SnipeitCustomField [[-id] <Int32>] [[-url] <String>] [[-apiKey] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -23,20 +23,28 @@ Get-SnipeitCustomField [[-id] <Int32>] [-url] <String> [-apiKey] <String> [<Comm
 
 ### EXAMPLE 1
 ```
-Get-SnipeitCustomField -url "https://assets.example.com" -token "token..."
+Get-SnipeitCustomField
+Get all custom fields
+```
+
+### EXAMPLE 2
+```
+Get-SnipeitCustomField -id 1
+Get custom field with ID 1
 ```
 
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -59,14 +67,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitDepartment.md
+++ b/docs/Get-SnipeitDepartment.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,12 +15,12 @@ Gets a list of Snipe-it Departments
 ### Search (Default)
 ```
 Get-SnipeitDepartment [-search <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all]
- [-sort <String>] -url <String> -apiKey <String> [<CommonParameters>]
+ [-sort <String>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with ID
 ```
-Get-SnipeitDepartment [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitDepartment [-id <Int32>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,7 +30,7 @@ Get-SnipeitDepartment [-id <Int32>] -url <String> -apiKey <String> [<CommonParam
 
 ### EXAMPLE 1
 ```
-Get-SnipeitDepartment -url "https://assets.example.com" -token "token..."
+Get-SnipeitDepartment
 ```
 
 ### EXAMPLE 2
@@ -61,14 +61,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -168,14 +169,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitFieldset.md
+++ b/docs/Get-SnipeitFieldset.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Returns a fieldset or list of Snipe-it Fieldsets
 ## SYNTAX
 
 ```
-Get-SnipeitFieldset [[-id] <Int32>] [-url] <String> [-apiKey] <String> [<CommonParameters>]
+Get-SnipeitFieldset [[-id] <Int32>] [[-url] <String>] [[-apiKey] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -23,25 +23,28 @@ Get-SnipeitFieldset [[-id] <Int32>] [-url] <String> [-apiKey] <String> [<CommonP
 
 ### EXAMPLE 1
 ```
-Get-SnipeitFieldset -url "https://assets.example.com" -token "token..."
+Get-SnipeitFieldset
+Get all fieldsets
 ```
 
 ### EXAMPLE 2
 ```
-Get-SnipeitFieldset -url "https://assets.example.com" -token "token..." | Where-Object {$_.name -eq "Windows" }
+Get-SnipeitFieldset  | Where-Object {$_.name -eq "Windows" }
+Gets fieldset by name
 ```
 
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,14 +67,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitLicense.md
+++ b/docs/Get-SnipeitLicense.md
@@ -26,6 +26,16 @@ Get-SnipeitLicense [-search <String>] [-name <String>] [-company_id <Int32>] [-p
 Get-SnipeitLicense [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
 ```
 
+### Get licenses checked out to user ID
+```
+Get-SnipeitLicense [-user_id <Int32>] [-all] -url <String> -apiKey <String> [<CommonParameters>]
+```
+
+### Get licenses checked out to asset ID
+```
+Get-SnipeitLicense [-asset_id <Int32>] [-all] -url <String> -apiKey <String> [<CommonParameters>]
+```
+
 ## DESCRIPTION
 {{ Fill in the Description }}
 
@@ -48,7 +58,7 @@ A return all results, works with -offset and other parameters
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Search
+Parameter Sets: Search, Get licenses checked out to user ID, Get licenses checked out to asset ID
 Aliases:
 
 Required: False
@@ -69,6 +79,21 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -asset_id
+{{ Fill asset_id Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: Get licenses checked out to asset ID
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -341,6 +366,21 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -user_id
+{{ Fill user_id Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: Get licenses checked out to user ID
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Get-SnipeitLicense.md
+++ b/docs/Get-SnipeitLicense.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -17,23 +17,23 @@ Gets a list of Snipe-it Licenses
 Get-SnipeitLicense [-search <String>] [-name <String>] [-company_id <Int32>] [-product_key <String>]
  [-order_number <String>] [-purchase_order <String>] [-license_name <String>] [-license_email <MailAddress>]
  [-manufacturer_id <Int32>] [-supplier_id <Int32>] [-depreciation_id <Int32>] [-category_id <Int32>]
- [-order <String>] [-sort <String>] [-limit <Int32>] [-offset <Int32>] [-all] -url <String> -apiKey <String>
- [<CommonParameters>]
+ [-order <String>] [-sort <String>] [-limit <Int32>] [-offset <Int32>] [-all] [-url <String>]
+ [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with ID
 ```
-Get-SnipeitLicense [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitLicense [-id <Int32>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get licenses checked out to user ID
 ```
-Get-SnipeitLicense [-user_id <Int32>] [-all] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitLicense [-user_id <Int32>] [-all] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get licenses checked out to asset ID
 ```
-Get-SnipeitLicense [-asset_id <Int32>] [-all] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitLicense [-asset_id <Int32>] [-all] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -69,14 +69,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -356,14 +357,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitLicenseSeat.md
+++ b/docs/Get-SnipeitLicenseSeat.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,7 +14,7 @@ Gets a list of Snipe-it Licenses Seats or specific Seat
 
 ```
 Get-SnipeitLicenseSeat [-id] <Int32> [[-seat_id] <Int32>] [[-limit] <Int32>] [[-offset] <Int32>] [-all]
- [-url] <String> [-apiKey] <String> [<CommonParameters>]
+ [[-url] <String>] [[-apiKey] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,14 +45,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 6
 Default value: None
 Accept pipeline input: False
@@ -122,14 +123,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 5
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitLocation.md
+++ b/docs/Get-SnipeitLocation.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,12 +15,12 @@ Gets a list of Snipe-it Locations
 ### Search (Default)
 ```
 Get-SnipeitLocation [-search <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all]
- -url <String> -apiKey <String> [<CommonParameters>]
+ [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with ID
 ```
-Get-SnipeitLocation [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitLocation [-id <Int32>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -56,14 +56,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -148,14 +149,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitManufacturer.md
+++ b/docs/Get-SnipeitManufacturer.md
@@ -1,6 +1,6 @@
 ---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,12 +15,12 @@ schema: 2.0.0
 ### Search (Default)
 ```
 Get-SnipeitManufacturer [-search <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all]
- -url <String> -apiKey <String> [<CommonParameters>]
+ [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with ID
 ```
-Get-SnipeitManufacturer [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitManufacturer [-id <Int32>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -58,14 +58,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -150,14 +151,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitModel.md
+++ b/docs/Get-SnipeitModel.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,13 +14,13 @@ Gets a list of Snipe-it Models
 
 ### Search (Default)
 ```
-Get-SnipeitModel [-search <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all] -url <String>
- -apiKey <String> [<CommonParameters>]
+Get-SnipeitModel [-search <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all] [-url <String>]
+ [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with ID
 ```
-Get-SnipeitModel [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitModel [-id <Int32>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -56,14 +56,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -148,14 +149,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitStatus.md
+++ b/docs/Get-SnipeitStatus.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,13 +14,13 @@ Gets a list of Snipe-it Status Labels
 
 ### Search (Default)
 ```
-Get-SnipeitStatus [-search <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all] -url <String>
- -apiKey <String> [<CommonParameters>]
+Get-SnipeitStatus [-search <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all]
+ [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with ID
 ```
-Get-SnipeitStatus [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitStatus [-id <Int32>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -56,14 +56,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -148,14 +149,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitSupplier.md
+++ b/docs/Get-SnipeitSupplier.md
@@ -1,6 +1,6 @@
 ---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,12 +15,12 @@ schema: 2.0.0
 ### Search (Default)
 ```
 Get-SnipeitSupplier [-search <String>] [-order <String>] [-limit <Int32>] [-offset <Int32>] [-all]
- -url <String> -apiKey <String> [<CommonParameters>]
+ [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with ID
 ```
-Get-SnipeitSupplier [-id <Int32>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitSupplier [-id <Int32>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -56,14 +56,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -148,14 +149,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-SnipeitUser.md
+++ b/docs/Get-SnipeitUser.md
@@ -24,6 +24,11 @@ Get-SnipeitUser [-search <String>] [-company_id <Int32>] [-location_id <Int32>] 
 Get-SnipeitUser [-id <String>] -url <String> -apiKey <String> [<CommonParameters>]
 ```
 
+### Get users a specific accessory id has been checked out to
+```
+Get-SnipeitUser [-accessory_id <String>] [-all] -url <String> -apiKey <String> [<CommonParameters>]
+```
+
 ## DESCRIPTION
 {{ Fill in the Description }}
 
@@ -49,14 +54,35 @@ Get-SnipeitUser -username someuser
 Get-SnipeitUser -email user@somedomain.com
 ```
 
+### EXAMPLE 5
+```
+Get-SnipeitUser -accessory_id 3
+Get users with accessory id 3 has been checked out to
+```
+
 ## PARAMETERS
+
+### -accessory_id
+{{ Fill accessory_id Description }}
+
+```yaml
+Type: String
+Parameter Sets: Get users a specific accessory id has been checked out to
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -all
 A return all results, works with -offset and other parameters
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Search
+Parameter Sets: Search, Get users a specific accessory id has been checked out to
 Aliases:
 
 Required: False

--- a/docs/Get-SnipeitUser.md
+++ b/docs/Get-SnipeitUser.md
@@ -1,6 +1,6 @@
 ---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -16,17 +16,17 @@ schema: 2.0.0
 ```
 Get-SnipeitUser [-search <String>] [-company_id <Int32>] [-location_id <Int32>] [-group_id <Int32>]
  [-department_id <Int32>] [-username <String>] [-email <String>] [-order <String>] [-limit <Int32>]
- [-offset <Int32>] [-all] -url <String> -apiKey <String> [<CommonParameters>]
+ [-offset <Int32>] [-all] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get with ID
 ```
-Get-SnipeitUser [-id <String>] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitUser [-id <String>] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ### Get users a specific accessory id has been checked out to
 ```
-Get-SnipeitUser [-accessory_id <String>] [-all] -url <String> -apiKey <String> [<CommonParameters>]
+Get-SnipeitUser [-accessory_id <String>] [-all] [-url <String>] [-apiKey <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -93,14 +93,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -260,14 +261,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitAccessory.md
+++ b/docs/New-SnipeitAccessory.md
@@ -16,7 +16,8 @@ Creates new accessory on Snipe-It system
 New-SnipeitAccessory [-name] <String> [-qty] <Int32> [-category_id] <Int32> [[-company_id] <Int32>]
  [[-manufacturer_id] <Int32>] [[-order_number] <String>] [[-model_number] <String>] [[-purchase_cost] <Single>]
  [[-purchase_date] <DateTime>] [[-min_amt] <Int32>] [[-supplier_id] <Int32>] [[-location_id] <Int32>]
- [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -40,7 +41,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 14
+Position: 15
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -72,6 +73,36 @@ Aliases:
 Required: False
 Position: 4
 Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 13
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -235,7 +266,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 13
+Position: 14
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitAccessory.md
+++ b/docs/New-SnipeitAccessory.md
@@ -14,8 +14,8 @@ Creates new accessory on Snipe-It system
 
 ```
 New-SnipeitAccessory [-name] <String> [-qty] <Int32> [-category_id] <Int32> [[-company_id] <Int32>]
- [[-manufacturer_id] <Int32>] [[-order_number] <String>] [[-purchase_cost] <Single>]
- [[-purchase_date] <DateTime>] [[-min_qty] <Int32>] [[-supplier_id] <Int32>] [[-location_id] <Int32>]
+ [[-manufacturer_id] <Int32>] [[-order_number] <String>] [[-model_number] <String>] [[-purchase_cost] <Single>]
+ [[-purchase_date] <DateTime>] [[-min_amt] <Int32>] [[-supplier_id] <Int32>] [[-location_id] <Int32>]
  [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -40,7 +40,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 13
+Position: 14
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -85,7 +85,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
+Position: 12
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -106,7 +106,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -min_qty
+### -min_amt
 Min quantity of the accessory before alert is triggered
 
 ```yaml
@@ -115,8 +115,23 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 10
 Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -model_number
+Model number for this accessory
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -160,7 +175,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -175,7 +190,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -205,7 +220,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: 11
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -220,7 +235,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 12
+Position: 13
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitAccessory.md
+++ b/docs/New-SnipeitAccessory.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -16,7 +16,7 @@ Creates new accessory on Snipe-It system
 New-SnipeitAccessory [-name] <String> [-qty] <Int32> [-category_id] <Int32> [[-company_id] <Int32>]
  [[-manufacturer_id] <Int32>] [[-order_number] <String>] [[-model_number] <String>] [[-purchase_cost] <Single>]
  [[-purchase_date] <DateTime>] [[-min_amt] <Int32>] [[-supplier_id] <Int32>] [[-location_id] <Int32>]
- [[-image] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-image] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -32,14 +32,15 @@ New-SnipeitAccessory -name "Accessory" -qty 3  -category_id 1
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 15
 Default value: None
 Accept pipeline input: False
@@ -242,14 +243,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 14
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitAccessory.md
+++ b/docs/New-SnipeitAccessory.md
@@ -16,8 +16,7 @@ Creates new accessory on Snipe-It system
 New-SnipeitAccessory [-name] <String> [-qty] <Int32> [-category_id] <Int32> [[-company_id] <Int32>]
  [[-manufacturer_id] <Int32>] [[-order_number] <String>] [[-model_number] <String>] [[-purchase_cost] <Single>]
  [[-purchase_date] <DateTime>] [[-min_amt] <Int32>] [[-supplier_id] <Int32>] [[-location_id] <Int32>]
- [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-image] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -78,7 +77,7 @@ Accept wildcard characters: False
 ```
 
 ### -image
-Image file name and path for item
+Accessory image fileame and path
 
 ```yaml
 Type: String
@@ -88,21 +87,6 @@ Aliases:
 Required: False
 Position: 13
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -image_delete
-Remove current image
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/New-SnipeitAsset.md
+++ b/docs/New-SnipeitAsset.md
@@ -12,12 +12,22 @@ Add a new Asset to Snipe-it asset system
 
 ## SYNTAX
 
+### Create asset (Default)
 ```
-New-SnipeitAsset [-status_id] <Int32> [-model_id] <Int32> [[-name] <String>] [[-asset_tag] <String>]
- [[-serial] <String>] [[-company_id] <Int32>] [[-order_number] <String>] [[-notes] <String>]
- [[-warranty_months] <Int32>] [[-purchase_cost] <String>] [[-purchase_date] <DateTime>]
- [[-supplier_id] <Int32>] [[-rtd_location_id] <Int32>] [[-image] <String>] [-url] <String> [-apiKey] <String>
- [[-customfields] <Hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-SnipeitAsset -status_id <Int32> -model_id <Int32> [-name <String>] [-asset_tag <String>] [-serial <String>]
+ [-company_id <Int32>] [-order_number <String>] [-notes <String>] [-warranty_months <Int32>]
+ [-purchase_cost <String>] [-purchase_date <DateTime>] [-supplier_id <Int32>] [-rtd_location_id <Int32>]
+ [-image <String>] -url <String> -apiKey <String> [-customfields <Hashtable>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### Checkout asset when creating
+```
+New-SnipeitAsset -status_id <Int32> -model_id <Int32> [-name <String>] [-asset_tag <String>] [-serial <String>]
+ [-company_id <Int32>] [-order_number <String>] [-notes <String>] [-warranty_months <Int32>]
+ [-purchase_cost <String>] [-purchase_date <DateTime>] [-supplier_id <Int32>] [-rtd_location_id <Int32>]
+ [-image <String>] -assigned_id <Int32> -checkout_to_type <String> -url <String> -apiKey <String>
+ [-customfields <Hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -54,7 +64,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 16
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -69,8 +79,38 @@ Parameter Sets: (All)
 Aliases: tag
 
 Required: False
-Position: 4
+Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -assigned_id
+Id of target user , location or asset
+
+```yaml
+Type: Int32
+Parameter Sets: Checkout asset when creating
+Aliases:
+
+Required: True
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -checkout_to_type
+Checkout asset when creating to one of following types user, location or asset.
+
+```yaml
+Type: String
+Parameter Sets: Checkout asset when creating
+Aliases:
+
+Required: True
+Position: Named
+Default value: User
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -84,7 +124,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: Named
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -100,7 +140,7 @@ Parameter Sets: (All)
 Aliases: CustomValues
 
 Required: False
-Position: 17
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -115,7 +155,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 14
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -130,7 +170,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 2
+Position: Named
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -145,7 +185,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -160,7 +200,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -175,7 +215,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -190,7 +230,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -205,7 +245,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -220,7 +260,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 13
+Position: Named
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -235,7 +275,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -250,7 +290,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 1
+Position: Named
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -265,7 +305,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 12
+Position: Named
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -280,7 +320,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 15
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -295,7 +335,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: Named
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitAsset.md
+++ b/docs/New-SnipeitAsset.md
@@ -16,8 +16,8 @@ Add a new Asset to Snipe-it asset system
 New-SnipeitAsset [-status_id] <Int32> [-model_id] <Int32> [[-name] <String>] [[-asset_tag] <String>]
  [[-serial] <String>] [[-company_id] <Int32>] [[-order_number] <String>] [[-notes] <String>]
  [[-warranty_months] <Int32>] [[-purchase_cost] <String>] [[-purchase_date] <DateTime>]
- [[-supplier_id] <Int32>] [[-rtd_location_id] <Int32>] [[-image] <String>] [-image_delete] [-url] <String>
- [-apiKey] <String> [[-customfields] <Hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-supplier_id] <Int32>] [[-rtd_location_id] <Int32>] [[-image] <String>] [-url] <String> [-apiKey] <String>
+ [[-customfields] <Hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 ```
 
 ### -image
-Image file name and path for item
+Asset image filename and path
 
 ```yaml
 Type: String
@@ -117,21 +117,6 @@ Aliases:
 Required: False
 Position: 14
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -image_delete
-Remove current image
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/New-SnipeitAsset.md
+++ b/docs/New-SnipeitAsset.md
@@ -16,8 +16,8 @@ Add a new Asset to Snipe-it asset system
 New-SnipeitAsset [-status_id] <Int32> [-model_id] <Int32> [[-name] <String>] [[-asset_tag] <String>]
  [[-serial] <String>] [[-company_id] <Int32>] [[-order_number] <String>] [[-notes] <String>]
  [[-warranty_months] <Int32>] [[-purchase_cost] <String>] [[-purchase_date] <DateTime>]
- [[-supplier_id] <Int32>] [[-rtd_location_id] <Int32>] [-url] <String> [-apiKey] <String>
- [[-customfields] <Hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-supplier_id] <Int32>] [[-rtd_location_id] <Int32>] [[-image] <String>] [-image_delete] [-url] <String>
+ [-apiKey] <String> [[-customfields] <Hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -54,7 +54,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 15
+Position: 16
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -100,8 +100,38 @@ Parameter Sets: (All)
 Aliases: CustomValues
 
 Required: False
-Position: 16
+Position: 17
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 14
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -265,7 +295,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 14
+Position: 15
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitAsset.md
+++ b/docs/New-SnipeitAsset.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -17,7 +17,7 @@ Add a new Asset to Snipe-it asset system
 New-SnipeitAsset -status_id <Int32> -model_id <Int32> [-name <String>] [-asset_tag <String>] [-serial <String>]
  [-company_id <Int32>] [-order_number <String>] [-notes <String>] [-warranty_months <Int32>]
  [-purchase_cost <String>] [-purchase_date <DateTime>] [-supplier_id <Int32>] [-rtd_location_id <Int32>]
- [-image <String>] -url <String> -apiKey <String> [-customfields <Hashtable>] [-WhatIf] [-Confirm]
+ [-image <String>] [-url <String>] [-apiKey <String>] [-customfields <Hashtable>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -26,7 +26,7 @@ New-SnipeitAsset -status_id <Int32> -model_id <Int32> [-name <String>] [-asset_t
 New-SnipeitAsset -status_id <Int32> -model_id <Int32> [-name <String>] [-asset_tag <String>] [-serial <String>]
  [-company_id <Int32>] [-order_number <String>] [-notes <String>] [-warranty_months <Int32>]
  [-purchase_cost <String>] [-purchase_date <DateTime>] [-supplier_id <Int32>] [-rtd_location_id <Int32>]
- [-image <String>] -assigned_id <Int32> -checkout_to_type <String> -url <String> -apiKey <String>
+ [-image <String>] -assigned_id <Int32> -checkout_to_type <String> [-url <String>] [-apiKey <String>]
  [-customfields <Hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -56,14 +56,15 @@ Using customfields when creating asset.
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -312,14 +313,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitAssetMaintenance.md
+++ b/docs/New-SnipeitAssetMaintenance.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,7 +15,7 @@ Add a new Asset maintenence to Snipe-it asset system
 ```
 New-SnipeitAssetMaintenance [-asset_id] <Int32> [-supplier_id] <Int32> [-asset_maintenance_type] <String>
  [-title] <String> [-start_date] <DateTime> [[-completion_date] <DateTime>] [[-is_warranty] <Boolean>]
- [[-cost] <Decimal>] [[-notes] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
+ [[-cost] <Decimal>] [[-notes] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -32,14 +32,15 @@ New-SnipeitAssetMaintenence -asset_id 1 -supplier_id 1 -title "replace keyboard"
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 11
 Default value: None
 Accept pipeline input: False
@@ -182,14 +183,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 10
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitAudit.md
+++ b/docs/New-SnipeitAudit.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Add a new Audit to Snipe-it asset system
 ## SYNTAX
 
 ```
-New-SnipeitAudit [-tag] <String> [[-location_id] <Int32>] [-url] <String> [-apiKey] <String> [-WhatIf]
+New-SnipeitAudit [-tag] <String> [[-location_id] <Int32>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -37,7 +37,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 4
 Default value: None
 Accept pipeline input: False
@@ -82,7 +82,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitCategory.md
+++ b/docs/New-SnipeitCategory.md
@@ -14,8 +14,8 @@ Create a new Snipe-IT Category
 
 ```
 New-SnipeitCategory [-name] <String> [-category_type] <String> [[-eula_text] <String>] [-use_default_eula]
- [-require_acceptance] [-checkin_email] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-require_acceptance] [-checkin_email] [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +39,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 5
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -90,6 +90,36 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -name
 Name of new category to be created
 
@@ -129,7 +159,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 4
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitCategory.md
+++ b/docs/New-SnipeitCategory.md
@@ -14,8 +14,8 @@ Create a new Snipe-IT Category
 
 ```
 New-SnipeitCategory [-name] <String> [-category_type] <String> [[-eula_text] <String>] [-use_default_eula]
- [-require_acceptance] [-checkin_email] [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-require_acceptance] [-checkin_email] [[-image] <String>] [-url] <String> [-apiKey] <String> [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -91,7 +91,7 @@ Accept wildcard characters: False
 ```
 
 ### -image
-Image file name and path for item
+Category image filename and path
 
 ```yaml
 Type: String
@@ -101,21 +101,6 @@ Aliases:
 Required: False
 Position: 4
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -image_delete
-Remove current image
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/New-SnipeitCategory.md
+++ b/docs/New-SnipeitCategory.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,7 +14,7 @@ Create a new Snipe-IT Category
 
 ```
 New-SnipeitCategory [-name] <String> [-category_type] <String> [[-eula_text] <String>] [-use_default_eula]
- [-require_acceptance] [-checkin_email] [[-image] <String>] [-url] <String> [-apiKey] <String> [-WhatIf]
+ [-require_acceptance] [-checkin_email] [[-image] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -25,20 +25,21 @@ New-SnipeitCategory [-name] <String> [-category_type] <String> [[-eula_text] <St
 
 ### EXAMPLE 1
 ```
-New-SnipeitCategory -name "Laptops" -category_type asset -url "Snipe-IT URL here..." -apiKey "API key here..."
+New-SnipeitCategory -name "Laptops" -category_type asset
 ```
 
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 6
 Default value: None
 Accept pipeline input: False
@@ -136,14 +137,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 5
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitCompany.md
+++ b/docs/New-SnipeitCompany.md
@@ -13,8 +13,8 @@ Creates a new Company
 ## SYNTAX
 
 ```
-New-SnipeitCompany [-name] <String> [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+New-SnipeitCompany [-name] <String> [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,8 +38,38 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 3
+Position: 4
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -68,7 +98,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 2
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitCompany.md
+++ b/docs/New-SnipeitCompany.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,8 +13,8 @@ Creates a new Company
 ## SYNTAX
 
 ```
-New-SnipeitCompany [-name] <String> [[-image] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+New-SnipeitCompany [-name] <String> [[-image] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,14 +30,15 @@ New-SnipeitCompany -name "Acme Company"
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 4
 Default value: None
 Accept pipeline input: False
@@ -75,14 +76,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitComponent.md
+++ b/docs/New-SnipeitComponent.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,7 +15,7 @@ Create a new component
 ```
 New-SnipeitComponent [-name] <String> [-category_id] <Int32> [-qty] <String> [[-company_id] <Int32>]
  [[-location_id] <Int32>] [[-order_number] <String>] [[-purchase_date] <DateTime>] [[-purchase_cost] <Single>]
- [[-image] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-image] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -25,20 +25,21 @@ Createa new componen on Snipe-It system
 
 ### EXAMPLE 1
 ```
-An example
+New-SnipeitComponent -name 'Display adapter' -catecory_id 3 -qty 10
 ```
 
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 11
 Default value: None
 Accept pipeline input: False
@@ -181,14 +182,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 10
 Default value: None
 Accept pipeline input: False
@@ -234,6 +236,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
-General notes
 
 ## RELATED LINKS

--- a/docs/New-SnipeitComponent.md
+++ b/docs/New-SnipeitComponent.md
@@ -15,7 +15,8 @@ Create a new component
 ```
 New-SnipeitComponent [-name] <String> [-category_id] <Int32> [-qty] <String> [[-company_id] <Int32>]
  [[-location_id] <Int32>] [[-order_number] <String>] [[-purchase_date] <DateTime>] [[-purchase_cost] <Single>]
- [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +40,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 10
+Position: 11
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -71,6 +72,36 @@ Aliases:
 Required: False
 Position: 4
 Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -174,7 +205,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 9
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitComponent.md
+++ b/docs/New-SnipeitComponent.md
@@ -15,8 +15,7 @@ Create a new component
 ```
 New-SnipeitComponent [-name] <String> [-category_id] <Int32> [-qty] <String> [[-company_id] <Int32>]
  [[-location_id] <Int32>] [[-order_number] <String>] [[-purchase_date] <DateTime>] [[-purchase_cost] <Single>]
- [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-image] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -77,7 +76,7 @@ Accept wildcard characters: False
 ```
 
 ### -image
-Image file name and path for item
+Component image filename and path
 
 ```yaml
 Type: String
@@ -87,21 +86,6 @@ Aliases:
 Required: False
 Position: 9
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -image_delete
-Remove current image
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/New-SnipeitConsumable.md
+++ b/docs/New-SnipeitConsumable.md
@@ -16,8 +16,8 @@ Add a new Consumable to Snipe-it asset system
 New-SnipeitConsumable [-name] <String> [-qty] <Int32> [-category_id] <Int32> [[-min_amt] <Int32>]
  [[-company_id] <Int32>] [[-order_number] <String>] [[-manufacturer_id] <Int32>] [[-location_id] <Int32>]
  [[-requestable] <Boolean>] [[-purchase_date] <DateTime>] [[-purchase_cost] <String>]
- [[-model_number] <String>] [[-item_no] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-model_number] <String>] [[-item_no] <String>] [[-image] <String>] [-image_delete] [-url] <String>
+ [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -42,7 +42,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 15
+Position: 16
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -74,6 +74,36 @@ Aliases:
 Required: False
 Position: 5
 Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 14
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -252,7 +282,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 14
+Position: 15
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitConsumable.md
+++ b/docs/New-SnipeitConsumable.md
@@ -16,8 +16,8 @@ Add a new Consumable to Snipe-it asset system
 New-SnipeitConsumable [-name] <String> [-qty] <Int32> [-category_id] <Int32> [[-min_amt] <Int32>]
  [[-company_id] <Int32>] [[-order_number] <String>] [[-manufacturer_id] <Int32>] [[-location_id] <Int32>]
  [[-requestable] <Boolean>] [[-purchase_date] <DateTime>] [[-purchase_cost] <String>]
- [[-model_number] <String>] [[-item_no] <String>] [[-image] <String>] [-image_delete] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-model_number] <String>] [[-item_no] <String>] [[-image] <String>] [-url] <String> [-apiKey] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -79,7 +79,7 @@ Accept wildcard characters: False
 ```
 
 ### -image
-Image file name and path for item
+Consumable Image filename and path
 
 ```yaml
 Type: String
@@ -89,21 +89,6 @@ Aliases:
 Required: False
 Position: 14
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -image_delete
-Remove current image
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/New-SnipeitConsumable.md
+++ b/docs/New-SnipeitConsumable.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -16,7 +16,7 @@ Add a new Consumable to Snipe-it asset system
 New-SnipeitConsumable [-name] <String> [-qty] <Int32> [-category_id] <Int32> [[-min_amt] <Int32>]
  [[-company_id] <Int32>] [[-order_number] <String>] [[-manufacturer_id] <Int32>] [[-location_id] <Int32>]
  [[-requestable] <Boolean>] [[-purchase_date] <DateTime>] [[-purchase_cost] <String>]
- [[-model_number] <String>] [[-item_no] <String>] [[-image] <String>] [-url] <String> [-apiKey] <String>
+ [[-model_number] <String>] [[-item_no] <String>] [[-image] <String>] [[-url] <String>] [[-apiKey] <String>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -34,14 +34,15 @@ Create consumable with stock count 20 , alert when stock is  5 or lower
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 16
 Default value: None
 Accept pipeline input: False
@@ -259,14 +260,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 15
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitCustomField.md
+++ b/docs/New-SnipeitCustomField.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,7 +15,7 @@ Add a new Custom Field to Snipe-it asset system
 ```
 New-SnipeitCustomField [-name] <String> [[-help_text] <String>] [-element] <String> [-format] <String>
  [[-field_values] <String>] [[-field_encrypted] <Boolean>] [[-show_in_email] <Boolean>]
- [[-custom_format] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-custom_format] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -31,14 +31,15 @@ New-SnipeitCustomField -Name "AntivirusInstalled" -Format "BOOLEAN" -HelpText "I
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 10
 Default value: None
 Accept pipeline input: False
@@ -167,14 +168,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 9
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitDepartment.md
+++ b/docs/New-SnipeitDepartment.md
@@ -14,7 +14,8 @@ Creates a department
 
 ```
 New-SnipeitDepartment [-name] <String> [[-company_id] <Int32>] [[-location_id] <Int32>] [[-manager_id] <Int32>]
- [[-notes] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-notes] <String>] [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +39,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 7
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -55,6 +56,36 @@ Aliases:
 Required: False
 Position: 2
 Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -128,7 +159,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 6
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitDepartment.md
+++ b/docs/New-SnipeitDepartment.md
@@ -61,7 +61,7 @@ Accept wildcard characters: False
 ```
 
 ### -image
-Image file name and path for item
+Department Image filename and path
 
 ```yaml
 Type: String
@@ -76,7 +76,7 @@ Accept wildcard characters: False
 ```
 
 ### -image_delete
-Remove current image
+{{ Fill image_delete Description }}
 
 ```yaml
 Type: SwitchParameter

--- a/docs/New-SnipeitDepartment.md
+++ b/docs/New-SnipeitDepartment.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,7 +14,7 @@ Creates a department
 
 ```
 New-SnipeitDepartment [-name] <String> [[-company_id] <Int32>] [[-location_id] <Int32>] [[-manager_id] <Int32>]
- [[-notes] <String>] [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf]
+ [[-notes] <String>] [[-image] <String>] [-image_delete] [[-url] <String>] [[-apiKey] <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -31,14 +31,15 @@ New-SnipeitDepartment -name "Department1" -company_id 1 -localtion_id 1 -manager
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 8
 Default value: None
 Accept pipeline input: False
@@ -151,14 +152,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 7
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitLicense.md
+++ b/docs/New-SnipeitLicense.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -17,7 +17,7 @@ New-SnipeitLicense [-name] <String> [-seats] <Int32> [[-category_id] <Int32>] [[
  [[-expiration_date] <DateTime>] [[-license_email] <MailAddress>] [[-license_name] <String>]
  [[-maintained] <Boolean>] [[-manufacturer_id] <Int32>] [[-notes] <String>] [[-order_number] <String>]
  [[-purchase_cost] <Single>] [[-purchase_date] <DateTime>] [[-reassignable] <Boolean>] [[-serial] <String>]
- [[-supplier_id] <Int32>] [[-termination_date] <DateTime>] [-url] <String> [-apiKey] <String> [-WhatIf]
+ [[-supplier_id] <Int32>] [[-termination_date] <DateTime>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -34,14 +34,15 @@ New-SnipeitLicence -name "License" -seats 3 -company_id 1
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 19
 Default value: None
 Accept pipeline input: False
@@ -304,14 +305,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 18
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitLocation.md
+++ b/docs/New-SnipeitLocation.md
@@ -122,7 +122,7 @@ Accept wildcard characters: False
 ```
 
 ### -image
-Image file name and path for item
+Location Image filename and path
 
 ```yaml
 Type: String
@@ -137,7 +137,7 @@ Accept wildcard characters: False
 ```
 
 ### -image_delete
-Remove current image
+{{ Fill image_delete Description }}
 
 ```yaml
 Type: SwitchParameter

--- a/docs/New-SnipeitLocation.md
+++ b/docs/New-SnipeitLocation.md
@@ -15,8 +15,8 @@ Add a new Location to Snipe-it asset system
 ```
 New-SnipeitLocation [-name] <String> [[-address] <String>] [[-address2] <String>] [[-city] <String>]
  [[-state] <String>] [[-country] <String>] [[-zip] <String>] [[-currency] <String>] [[-parent_id] <Int32>]
- [[-manager_id] <Int32>] [[-ldap_ou] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-manager_id] <Int32>] [[-ldap_ou] <String>] [[-image] <String>] [-image_delete] [-url] <String>
+ [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -70,7 +70,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 13
+Position: 14
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -117,6 +117,36 @@ Aliases:
 Required: False
 Position: 8
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 12
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -205,7 +235,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 12
+Position: 13
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitLocation.md
+++ b/docs/New-SnipeitLocation.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,8 +15,8 @@ Add a new Location to Snipe-it asset system
 ```
 New-SnipeitLocation [-name] <String> [[-address] <String>] [[-address2] <String>] [[-city] <String>]
  [[-state] <String>] [[-country] <String>] [[-zip] <String>] [[-currency] <String>] [[-parent_id] <Int32>]
- [[-manager_id] <Int32>] [[-ldap_ou] <String>] [[-image] <String>] [-image_delete] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-manager_id] <Int32>] [[-ldap_ou] <String>] [[-image] <String>] [-image_delete] [[-url] <String>]
+ [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -62,14 +62,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 14
 Default value: None
 Accept pipeline input: False
@@ -227,14 +228,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 13
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitManufacturer.md
+++ b/docs/New-SnipeitManufacturer.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,8 +13,8 @@ Add a new Manufacturer to Snipe-it asset system
 ## SYNTAX
 
 ```
-New-SnipeitManufacturer [-Name] <String> [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+New-SnipeitManufacturer [-Name] <String> [[-image] <String>] [-image_delete] [[-url] <String>]
+ [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,14 +30,15 @@ New-SnipeitManufacturer -name "HP"
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 4
 Default value: None
 Accept pipeline input: False
@@ -90,14 +91,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitManufacturer.md
+++ b/docs/New-SnipeitManufacturer.md
@@ -13,8 +13,8 @@ Add a new Manufacturer to Snipe-it asset system
 ## SYNTAX
 
 ```
-New-SnipeitManufacturer [-Name] <String> [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+New-SnipeitManufacturer [-Name] <String> [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,8 +38,38 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 3
+Position: 4
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -68,7 +98,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 2
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitManufacturer.md
+++ b/docs/New-SnipeitManufacturer.md
@@ -45,7 +45,7 @@ Accept wildcard characters: False
 ```
 
 ### -image
-Image file name and path for item
+Manufacturer Image filename and path
 
 ```yaml
 Type: String

--- a/docs/New-SnipeitModel.md
+++ b/docs/New-SnipeitModel.md
@@ -14,8 +14,8 @@ Add a new Model to Snipe-it asset system
 
 ```
 New-SnipeitModel [-name] <String> [[-model_number] <String>] [-category_id] <Int32> [-manufacturer_id] <Int32>
- [[-eol] <Int32>] [-fieldset_id] <Int32> [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-eol] <Int32>] [-fieldset_id] <Int32> [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +39,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 8
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -86,6 +86,36 @@ Aliases:
 Required: True
 Position: 6
 Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -144,7 +174,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 7
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitModel.md
+++ b/docs/New-SnipeitModel.md
@@ -14,8 +14,8 @@ Add a new Model to Snipe-it asset system
 
 ```
 New-SnipeitModel [-name] <String> [[-model_number] <String>] [-category_id] <Int32> [-manufacturer_id] <Int32>
- [[-eol] <Int32>] [-fieldset_id] <Int32> [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-eol] <Int32>] [-fieldset_id] <Int32> [[-image] <String>] [-url] <String> [-apiKey] <String> [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -91,7 +91,7 @@ Accept wildcard characters: False
 ```
 
 ### -image
-Image file name and path for item
+Asset model Image filename and path
 
 ```yaml
 Type: String
@@ -101,21 +101,6 @@ Aliases:
 Required: False
 Position: 7
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -image_delete
-Remove current image
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/New-SnipeitModel.md
+++ b/docs/New-SnipeitModel.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,7 +14,7 @@ Add a new Model to Snipe-it asset system
 
 ```
 New-SnipeitModel [-name] <String> [[-model_number] <String>] [-category_id] <Int32> [-manufacturer_id] <Int32>
- [[-eol] <Int32>] [-fieldset_id] <Int32> [[-image] <String>] [-url] <String> [-apiKey] <String> [-WhatIf]
+ [[-eol] <Int32>] [-fieldset_id] <Int32> [[-image] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -31,14 +31,15 @@ New-SnipeitModel -name "DL380" -manufacturer_id 2 -fieldset_id 2 -category_id 1
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 9
 Default value: None
 Accept pipeline input: False
@@ -151,14 +152,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 8
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitSupplier.md
+++ b/docs/New-SnipeitSupplier.md
@@ -1,4 +1,4 @@
----
+﻿---
 external help file: SnipeitPS-help.xml
 Module Name: SnipeitPS
 online version:

--- a/docs/New-SnipeitSupplier.md
+++ b/docs/New-SnipeitSupplier.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,8 +15,8 @@ Creates a supplier
 ```
 New-SnipeitSupplier [-name] <String> [[-address] <String>] [[-address2] <String>] [[-city] <String>]
  [[-state] <String>] [[-country] <String>] [[-zip] <String>] [[-phone] <String>] [[-fax] <String>]
- [[-email] <String>] [[-contact] <String>] [[-notes] <String>] [[-image] <String>] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-email] <String>] [[-contact] <String>] [[-notes] <String>] [[-image] <String>] [[-url] <String>]
+ [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -62,14 +62,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 15
 Default value: None
 Accept pipeline input: False
@@ -227,14 +228,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 14
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitSupplier.md
+++ b/docs/New-SnipeitSupplier.md
@@ -1,0 +1,299 @@
+---
+external help file: SnipeitPS-help.xml
+Module Name: SnipeitPS
+online version:
+schema: 2.0.0
+---
+
+# New-SnipeitSupplier
+
+## SYNOPSIS
+Creates a supplier
+
+## SYNTAX
+
+```
+New-SnipeitSupplier [-name] <String> [[-address] <String>] [[-address2] <String>] [[-city] <String>]
+ [[-state] <String>] [[-country] <String>] [[-zip] <String>] [[-phone] <String>] [[-fax] <String>]
+ [[-email] <String>] [[-contact] <String>] [[-notes] <String>] [[-image] <String>] [-url] <String>
+ [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a new supplier on Snipe-It system
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+New-SnipeitDepartment -name "Department1" -company_id 1 -localtion_id 1 -manager_id 3
+```
+
+## PARAMETERS
+
+### -address
+Address line 1 of supplier
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -address2
+Address line 1 of supplier
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -apiKey
+Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 15
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -city
+City
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -contact
+Contact person
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 11
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -country
+Country
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -email
+Email address
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -fax
+Fax number
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 13
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -name
+Department Name
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -notes
+Email address
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 12
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -phone
+Phone number
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -state
+State
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -url
+URL of Snipeit system, can be set using Set-SnipeitInfo command
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 14
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -zip
+Zip code
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/New-SnipeitUser.md
+++ b/docs/New-SnipeitUser.md
@@ -16,8 +16,8 @@ Creates a new user
 New-SnipeitUser [-first_name] <String> [-last_name] <String> [-username] <String> [[-password] <String>]
  [[-activated] <Boolean>] [[-notes] <String>] [[-jobtitle] <String>] [[-email] <String>] [[-phone] <String>]
  [[-company_id] <Int32>] [[-location_id] <Int32>] [[-department_id] <Int32>] [[-manager_id] <Int32>]
- [[-employee_num] <String>] [[-ldap_import] <Boolean>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-employee_num] <String>] [[-ldap_import] <Boolean>] [[-image] <String>] [-image_delete] [-url] <String>
+ [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -57,7 +57,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 17
+Position: 18
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -134,6 +134,36 @@ Aliases:
 Required: True
 Position: 1
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 16
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -267,7 +297,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 16
+Position: 17
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-SnipeitUser.md
+++ b/docs/New-SnipeitUser.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -16,8 +16,8 @@ Creates a new user
 New-SnipeitUser [-first_name] <String> [-last_name] <String> [-username] <String> [[-password] <String>]
  [[-activated] <Boolean>] [[-notes] <String>] [[-jobtitle] <String>] [[-email] <String>] [[-phone] <String>]
  [[-company_id] <Int32>] [[-location_id] <Int32>] [[-department_id] <Int32>] [[-manager_id] <Int32>]
- [[-employee_num] <String>] [[-ldap_import] <Boolean>] [[-image] <String>] [-url] <String> [-apiKey] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-employee_num] <String>] [[-ldap_import] <Boolean>] [[-image] <String>] [[-url] <String>]
+ [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -49,14 +49,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 18
 Default value: None
 Accept pipeline input: False
@@ -274,14 +275,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 17
 Default value: None
 Accept pipeline input: False

--- a/docs/New-SnipeitUser.md
+++ b/docs/New-SnipeitUser.md
@@ -16,8 +16,8 @@ Creates a new user
 New-SnipeitUser [-first_name] <String> [-last_name] <String> [-username] <String> [[-password] <String>]
  [[-activated] <Boolean>] [[-notes] <String>] [[-jobtitle] <String>] [[-email] <String>] [[-phone] <String>]
  [[-company_id] <Int32>] [[-location_id] <Int32>] [[-department_id] <Int32>] [[-manager_id] <Int32>]
- [[-employee_num] <String>] [[-ldap_import] <Boolean>] [[-image] <String>] [-image_delete] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-employee_num] <String>] [[-ldap_import] <Boolean>] [[-image] <String>] [-url] <String> [-apiKey] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -139,7 +139,7 @@ Accept wildcard characters: False
 ```
 
 ### -image
-Image file name and path for item
+User Image file name and path
 
 ```yaml
 Type: String
@@ -149,21 +149,6 @@ Aliases:
 Required: False
 Position: 16
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -image_delete
-Remove current image
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Remove-SnipeitAccessory.md
+++ b/docs/Remove-SnipeitAccessory.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes Accessory from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitAccessory [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitAccessory [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -34,15 +34,16 @@ Get-SnipeitAccessory -search needle  | Remove-SnipeitAccessory
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitAsset.md
+++ b/docs/Remove-SnipeitAsset.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes Asset from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitAsset [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitAsset [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -34,15 +34,16 @@ Get-SnipeitAsset -serial 123456789  | Remove-SnipeitAsset
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitAssetMaintenance.md
+++ b/docs/Remove-SnipeitAssetMaintenance.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Remove asset maintenance from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitAssetMaintenance [-id] <Int32[]> [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitAssetMaintenance [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -24,20 +24,20 @@ Removes asset maintenance event or events from Snipe-it asset system by ID
 
 ### EXAMPLE 1
 ```
-Remove-SnipeitAssetMaintenance -ID 44 -url $url -apiKey $secret -Verbose
+Remove-SnipeitAssetMaintenance -ID 44
 ```
 
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+{{ Fill apiKey Description }}
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -60,14 +60,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitCategory.md
+++ b/docs/Remove-SnipeitCategory.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes category from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitCategory [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitCategory [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -24,7 +24,7 @@ Removes category or multiple categories from Snipe-it asset system
 
 ### EXAMPLE 1
 ```
-Remove-SnipeitCategory -ID 44 -Verbose
+Remove-SnipeitCategory -ID 44
 ```
 
 ### EXAMPLE 2
@@ -34,15 +34,16 @@ Get-SnipeitCategory -search something  | Remove-SnipeitCategory
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitCompany.md
+++ b/docs/Remove-SnipeitCompany.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes Company from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitCompany [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitCompany [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -24,7 +24,7 @@ Removes Company or multiple Companies from Snipe-it asset system
 
 ### EXAMPLE 1
 ```
-Remove-SnipeitCompany -ID 44 -Verbose
+Remove-SnipeitCompany -ID 44
 ```
 
 ### EXAMPLE 2
@@ -34,15 +34,16 @@ Get-SnipeitCompany | | Where-object {$_.name -like '*some*'} | Remove-SnipeitCom
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitComponent.md
+++ b/docs/Remove-SnipeitComponent.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes component from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitComponent [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitComponent [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -24,7 +24,7 @@ Removes component or multiple components from Snipe-it asset system
 
 ### EXAMPLE 1
 ```
-Remove-SnipeitComponent -ID 44 -Verbose
+Remove-SnipeitComponent -ID 44
 ```
 
 ### EXAMPLE 2
@@ -34,15 +34,16 @@ Get-SnipeitComponent -search 123456789  | Remove-SnipeitComponent
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitConsumable.md
+++ b/docs/Remove-SnipeitConsumable.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes consumable from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitConsumable [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitConsumable [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -24,25 +24,26 @@ Removes consumable or multiple consumables from Snipe-it asset system
 
 ### EXAMPLE 1
 ```
-Remove-SnipeitConsumable -ID 44 -Verbose
+Remove-SnipeitConsumable -ID 44
 ```
 
 ### EXAMPLE 2
 ```
-Get-SnipeitConsumable -search "paper"  | Remove-Snipeitconsumable
+Get-SnipeitConsumable -search "paper"  | Remove-SnipeitConsumable
 ```
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitCustomField.md
+++ b/docs/Remove-SnipeitCustomField.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes custom field from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitCustomField [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitCustomField [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -34,15 +34,16 @@ Get-SnipeitCustomField | Where-object {$_.name -like '*address*'}  | Remove-Snip
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitDepartment.md
+++ b/docs/Remove-SnipeitDepartment.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes department from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitDepartment [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitDepartment [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -24,7 +24,7 @@ Removes department or multiple departments from Snipe-it asset system
 
 ### EXAMPLE 1
 ```
-Remove-SnipeitDepartment -ID 44 -Verbose
+Remove-SnipeitDepartment -ID 44
 ```
 
 ### EXAMPLE 2
@@ -34,15 +34,16 @@ Get-SnipeitDepartment | Where-object {$_.name -like '*head*'} | Remove-SnipeitDe
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitLicense.md
+++ b/docs/Remove-SnipeitLicense.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes licence from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitLicense [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitLicense [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -24,7 +24,7 @@ Removes licence or multiple licenses from Snipe-it asset system
 
 ### EXAMPLE 1
 ```
-Remove-SnipeitLicence -ID 44 -Verbose
+Remove-SnipeitLicence -ID 44
 ```
 
 ### EXAMPLE 2
@@ -34,15 +34,16 @@ Get-SnipeitLicence -product_key 123456789  | Remove-SnipeitLicense
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitLocation.md
+++ b/docs/Remove-SnipeitLocation.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes Location from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitLocation [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitLocation [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -24,7 +24,7 @@ Removes localtion or multiple locations from Snipe-it asset system
 
 ### EXAMPLE 1
 ```
-Remove-SnipeitLocation -ID 44 -Verbose
+Remove-SnipeitLocation -ID 44
 ```
 
 ### EXAMPLE 2
@@ -34,15 +34,16 @@ Get-SnipeitLocation -city Arkham  | Remove-SnipeitLocation
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitManufacturer.md
+++ b/docs/Remove-SnipeitManufacturer.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes manufacturer from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitManufacturer [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitManufacturer [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -24,7 +24,7 @@ Removes manufacturer or multiple manufacturers from Snipe-it asset system
 
 ### EXAMPLE 1
 ```
-Remove-SnipeitManufacturer -ID 44 -Verbose
+Remove-SnipeitManufacturer -ID 44
 ```
 
 ### EXAMPLE 2
@@ -34,15 +34,16 @@ Get-SnipeitManufacturer | Where-object {$_.name -like '*something*'}  | Remove-S
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitModel.md
+++ b/docs/Remove-SnipeitModel.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes Asset model from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitModel [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitModel [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -24,7 +24,7 @@ Removes asset model or multiple assets models from Snipe-it asset system
 
 ### EXAMPLE 1
 ```
-Remove-SnipeitModel -ID 44 -Verbose
+Remove-SnipeitModel -ID 44
 ```
 
 ### EXAMPLE 2
@@ -34,15 +34,16 @@ Get-SnipeitModel -search needle  | Remove-SnipeitModel
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitSupplier.md
+++ b/docs/Remove-SnipeitSupplier.md
@@ -1,0 +1,122 @@
+---
+external help file: SnipeitPS-help.xml
+Module Name: SnipeitPS
+online version:
+schema: 2.0.0
+---
+
+# Remove-SnipeitSupplier
+
+## SYNOPSIS
+Removes supplier from Snipe-it asset system
+
+## SYNTAX
+
+```
+Remove-SnipeitSupplier [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Removes supplier or multiple manufacturers from Snipe-it asset system
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Remove-SnipeitSupplier -ID 44
+```
+
+### EXAMPLE 2
+```
+Get-SnipeitSupplier | Where-object {$_.name -like '*something*'}  | Remove-SnipeitSupplier
+```
+
+## PARAMETERS
+
+### -APIKey
+User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -id
+Unique ID For supplier to be removed
+
+```yaml
+Type: Int32[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -URL
+URL of Snipeit system, can be set using Set-SnipeitInfo command
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/Remove-SnipeitSupplier.md
+++ b/docs/Remove-SnipeitSupplier.md
@@ -1,4 +1,4 @@
----
+﻿---
 external help file: SnipeitPS-help.xml
 Module Name: SnipeitPS
 online version:

--- a/docs/Remove-SnipeitSupplier.md
+++ b/docs/Remove-SnipeitSupplier.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Removes supplier from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitSupplier [-id] <Int32[]> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm]
+Remove-SnipeitSupplier [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -34,15 +34,16 @@ Get-SnipeitSupplier | Where-object {$_.name -like '*something*'}  | Remove-Snipe
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -64,15 +65,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Remove-SnipeitUser.md
+++ b/docs/Remove-SnipeitUser.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,8 @@ Removes User from Snipe-it asset system
 ## SYNTAX
 
 ```
-Remove-SnipeitUser [-id] <Int32> [-URL] <String> [-APIKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-SnipeitUser [-id] <Int32[]> [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -28,15 +29,16 @@ Remove-SnipeitUser -ID 44 -url $url -apiKey $secret -Verbose
 
 ## PARAMETERS
 
-### -APIKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+### -apiKey
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -47,26 +49,27 @@ Accept wildcard characters: False
 Unique ID For User to be removed
 
 ```yaml
-Type: Int32
+Type: Int32[]
 Parameter Sets: (All)
 Aliases:
 
 Required: True
 Position: 1
-Default value: 0
+Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -URL
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+### -url
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Reset-SnipeitAccessoryOwner.md
+++ b/docs/Reset-SnipeitAccessoryOwner.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,7 +13,7 @@ Checkin  accessories
 ## SYNTAX
 
 ```
-Reset-SnipeitAccessoryOwner [-assigned_pivot_id] <Int32> [-url] <String> [-apiKey] <String> [-WhatIf]
+Reset-SnipeitAccessoryOwner [-assigned_pivot_id] <Int32> [[-url] <String>] [[-apiKey] <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -36,14 +36,15 @@ Get-SnipeitAccessoryOwner -assigned_pivot_id xxx
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -67,14 +68,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/Reset-SnipeitAssetOwner.md
+++ b/docs/Reset-SnipeitAssetOwner.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,7 +14,7 @@ Checkin asset
 
 ```
 Reset-SnipeitAssetOwner [-id] <Int32> [[-status_id] <Int32>] [[-location_id] <Int32>] [[-notes] <String>]
- [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -24,20 +24,21 @@ Checks asset in from current user/localtion/asset
 
 ### EXAMPLE 1
 ```
-Remove-SnipeitUser -ID 44 -url $url -apiKey $secret -Verbose
+Remove-SnipeitUser -ID 44
 ```
 
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfoeItInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 6
 Default value: None
 Accept pipeline input: False
@@ -105,14 +106,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 5
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitAccessory.md
+++ b/docs/Set-SnipeitAccessory.md
@@ -16,7 +16,8 @@ Updates accessory on Snipe-It system
 Set-SnipeitAccessory [-id] <Int32[]> [[-name] <String>] [[-qty] <Int32>] [[-category_id] <Int32>]
  [[-company_id] <Int32>] [[-manufacturer_id] <Int32>] [[-model_number] <String>] [[-order_number] <String>]
  [[-purchase_cost] <Single>] [[-purchase_date] <DateTime>] [[-min_amt] <Int32>] [[-supplier_id] <Int32>]
- [[-location_id] <Int32>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-location_id] <Int32>] [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -40,7 +41,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 15
+Position: 16
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -88,6 +89,36 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 14
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -250,7 +281,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 14
+Position: 15
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitAccessory.md
+++ b/docs/Set-SnipeitAccessory.md
@@ -16,8 +16,8 @@ Updates accessory on Snipe-It system
 Set-SnipeitAccessory [-id] <Int32[]> [[-name] <String>] [[-qty] <Int32>] [[-category_id] <Int32>]
  [[-company_id] <Int32>] [[-manufacturer_id] <Int32>] [[-model_number] <String>] [[-order_number] <String>]
  [[-purchase_cost] <Single>] [[-purchase_date] <DateTime>] [[-min_amt] <Int32>] [[-supplier_id] <Int32>]
- [[-location_id] <Int32>] [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [[-location_id] <Int32>] [[-image] <String>] [-image_delete] [[-RequestType] <String>] [-url] <String>
+ [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -41,7 +41,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 16
+Position: 17
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -257,6 +257,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 15
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -supplier_id
 ID number of the supplier for this accessory
 
@@ -281,7 +297,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 15
+Position: 16
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitAccessory.md
+++ b/docs/Set-SnipeitAccessory.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -16,8 +16,8 @@ Updates accessory on Snipe-It system
 Set-SnipeitAccessory [-id] <Int32[]> [[-name] <String>] [[-qty] <Int32>] [[-category_id] <Int32>]
  [[-company_id] <Int32>] [[-manufacturer_id] <Int32>] [[-model_number] <String>] [[-order_number] <String>]
  [[-purchase_cost] <Single>] [[-purchase_date] <DateTime>] [[-min_amt] <Int32>] [[-supplier_id] <Int32>]
- [[-location_id] <Int32>] [[-image] <String>] [-image_delete] [[-RequestType] <String>] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-location_id] <Int32>] [[-image] <String>] [-image_delete] [[-RequestType] <String>] [[-url] <String>]
+ [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -33,14 +33,15 @@ Set-SnipeitAccessory -id 1 -qty 3
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfoeItInfoeItInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 17
 Default value: None
 Accept pipeline input: False
@@ -289,14 +290,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 16
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitAccessory.md
+++ b/docs/Set-SnipeitAccessory.md
@@ -16,7 +16,7 @@ Updates accessory on Snipe-It system
 Set-SnipeitAccessory [-id] <Int32[]> [[-name] <String>] [[-qty] <Int32>] [[-category_id] <Int32>]
  [[-company_id] <Int32>] [[-manufacturer_id] <Int32>] [[-model_number] <String>] [[-order_number] <String>]
  [[-purchase_cost] <Single>] [[-purchase_date] <DateTime>] [[-min_amt] <Int32>] [[-supplier_id] <Int32>]
- [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-location_id] <Int32>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -40,7 +40,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 14
+Position: 15
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -88,6 +88,21 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -location_id
+ID number of the location the accessory is assigned to
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 13
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -235,7 +250,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 13
+Position: 14
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitAccessory.md
+++ b/docs/Set-SnipeitAccessory.md
@@ -14,9 +14,9 @@ Updates accessory on Snipe-It system
 
 ```
 Set-SnipeitAccessory [-id] <Int32[]> [[-name] <String>] [[-qty] <Int32>] [[-category_id] <Int32>]
- [[-company_id] <Int32>] [[-manufacturer_id] <Int32>] [[-order_number] <String>] [[-purchase_cost] <Single>]
- [[-purchase_date] <DateTime>] [[-min_amt] <Int32>] [[-supplier_id] <Int32>] [-url] <String> [-apiKey] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-company_id] <Int32>] [[-manufacturer_id] <Int32>] [[-model_number] <String>] [[-order_number] <String>]
+ [[-purchase_cost] <Single>] [[-purchase_date] <DateTime>] [[-min_amt] <Int32>] [[-supplier_id] <Int32>]
+ [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -40,7 +40,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 13
+Position: 14
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -115,7 +115,22 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: 11
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -model_number
+Model number for this accessory
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -145,7 +160,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -160,7 +175,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 9
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -175,7 +190,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -205,7 +220,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
+Position: 12
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -220,7 +235,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 12
+Position: 13
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitAccessoryOwner.md
+++ b/docs/Set-SnipeitAccessoryOwner.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,8 +13,8 @@ Checkout accessory
 ## SYNTAX
 
 ```
-Set-SnipeitAccessoryOwner [-id] <Int32[]> [-assigned_to] <Int32> [[-note] <String>] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-SnipeitAccessoryOwner [-id] <Int32[]> [-assigned_to] <Int32> [[-note] <String>] [[-url] <String>]
+ [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,14 +30,15 @@ Set-SnipeitAccessoryOwner -id 1 -assigned_id 1  -note "testing check out to user
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 5
 Default value: None
 Accept pipeline input: False
@@ -90,14 +91,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 4
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitAsset.md
+++ b/docs/Set-SnipeitAsset.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -17,8 +17,8 @@ Set-SnipeitAsset [-id] <Int32[]> [[-name] <String>] [[-status_id] <Int32>] [[-mo
  [[-last_checkout] <DateTime>] [[-assigned_to] <Int32>] [[-company_id] <Int32>] [[-serial] <String>]
  [[-order_number] <String>] [[-warranty_months] <Int32>] [[-purchase_cost] <Double>]
  [[-purchase_date] <DateTime>] [[-requestable] <Boolean>] [[-archived] <Boolean>] [[-rtd_location_id] <Int32>]
- [[-notes] <String>] [[-RequestType] <String>] [[-image] <String>] [-image_delete] [-url] <String>
- [-apiKey] <String> [[-customfields] <Hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-notes] <String>] [[-RequestType] <String>] [[-image] <String>] [-image_delete] [[-url] <String>]
+ [[-apiKey] <String>] [[-customfields] <Hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,14 +44,15 @@ Get-SnipeitAsset -serial 12345678 | Set-SnipeitAsset -notes 'Just updated'
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfoeItInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 20
 Default value: None
 Accept pipeline input: False
@@ -346,14 +347,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfoeItInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 19
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitAsset.md
+++ b/docs/Set-SnipeitAsset.md
@@ -17,8 +17,8 @@ Set-SnipeitAsset [-id] <Int32[]> [[-name] <String>] [[-status_id] <Int32>] [[-mo
  [[-last_checkout] <DateTime>] [[-assigned_to] <Int32>] [[-company_id] <Int32>] [[-serial] <String>]
  [[-order_number] <String>] [[-warranty_months] <Int32>] [[-purchase_cost] <Double>]
  [[-purchase_date] <DateTime>] [[-requestable] <Boolean>] [[-archived] <Boolean>] [[-rtd_location_id] <Int32>]
- [[-notes] <String>] [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [[-customfields] <Hashtable>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-notes] <String>] [[-RequestType] <String>] [[-image] <String>] [-image_delete] [-url] <String>
+ [-apiKey] <String> [[-customfields] <Hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -52,7 +52,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 19
+Position: 20
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -113,7 +113,7 @@ Parameter Sets: (All)
 Aliases: CustomValues
 
 Required: False
-Position: 20
+Position: 21
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -131,6 +131,36 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 18
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -256,7 +286,7 @@ Accept wildcard characters: False
 
 ### -RequestType
 Http request type to send Snipe IT system.
-Defaults to Put youc use Patch if needed
+Defaults to Patch you could use Put if needed.
 
 ```yaml
 Type: String
@@ -324,7 +354,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 18
+Position: 19
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitAssetOwner.md
+++ b/docs/Set-SnipeitAssetOwner.md
@@ -76,7 +76,7 @@ Accept wildcard characters: False
 ```
 
 ### -checkout_to_type
-{{ Fill checkout_to_type Description }}
+Checkout asset to one of following types user, location, asset
 
 ```yaml
 Type: String

--- a/docs/Set-SnipeitAssetOwner.md
+++ b/docs/Set-SnipeitAssetOwner.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,8 +14,8 @@ Checkout asset
 
 ```
 Set-SnipeitAssetOwner [-id] <Int32[]> [-assigned_id] <Int32> [[-checkout_to_type] <String>] [[-name] <String>]
- [[-note] <String>] [[-expected_checkin] <DateTime>] [[-checkout_at] <DateTime>] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-note] <String>] [[-expected_checkin] <DateTime>] [[-checkout_at] <DateTime>] [[-url] <String>]
+ [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -31,14 +31,15 @@ Set-SnipeitAssetOwner -id 1 -assigned_id 1 -checkout_to_type user -note "testing
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 9
 Default value: None
 Accept pipeline input: False
@@ -154,14 +155,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 8
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitCategory.md
+++ b/docs/Set-SnipeitCategory.md
@@ -15,8 +15,8 @@ Create a new Snipe-IT Category
 ```
 Set-SnipeitCategory [-id] <Int32[]> [[-name] <String>] [[-category_type] <String>] [[-eula_text] <String>]
  [[-use_default_eula] <Boolean>] [[-require_acceptance] <Boolean>] [[-checkin_email] <Boolean>]
- [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-image] <String>] [-image_delete] [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -40,7 +40,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 10
+Position: 11
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -151,6 +151,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -require_acceptance
 If switch is present, require users to confirm acceptance of assets in this category
 
@@ -175,7 +191,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 9
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitCategory.md
+++ b/docs/Set-SnipeitCategory.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,7 +15,7 @@ Create a new Snipe-IT Category
 ```
 Set-SnipeitCategory [-id] <Int32[]> [[-name] <String>] [[-category_type] <String>] [[-eula_text] <String>]
  [[-use_default_eula] <Boolean>] [[-require_acceptance] <Boolean>] [[-checkin_email] <Boolean>]
- [[-image] <String>] [-image_delete] [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf]
+ [[-image] <String>] [-image_delete] [[-RequestType] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -32,14 +32,15 @@ Set-SnipeitCategory -id 4 -name "Laptops"
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 11
 Default value: None
 Accept pipeline input: False
@@ -183,14 +184,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 10
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitCategory.md
+++ b/docs/Set-SnipeitCategory.md
@@ -14,8 +14,9 @@ Create a new Snipe-IT Category
 
 ```
 Set-SnipeitCategory [-id] <Int32[]> [[-name] <String>] [[-category_type] <String>] [[-eula_text] <String>]
- [[-use_default_eula] <Boolean>] [[-require_acceptance] <Boolean>] [[-checkin_email] <Boolean>] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-use_default_eula] <Boolean>] [[-require_acceptance] <Boolean>] [[-checkin_email] <Boolean>]
+ [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +40,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 9
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -105,6 +106,36 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -name
 Name of new category to be created
 
@@ -144,7 +175,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 8
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitCompany.md
+++ b/docs/Set-SnipeitCompany.md
@@ -13,8 +13,8 @@ Updates company name
 ## SYNTAX
 
 ```
-Set-SnipeitCompany [-id] <Int32[]> [-name] <String> [[-image] <String>] [-image_delete] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-SnipeitCompany [-id] <Int32[]> [-name] <String> [[-image] <String>] [-image_delete]
+ [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 5
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -104,6 +104,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -113,7 +129,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 4
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitCompany.md
+++ b/docs/Set-SnipeitCompany.md
@@ -13,8 +13,8 @@ Updates company name
 ## SYNTAX
 
 ```
-Set-SnipeitCompany [-id] <Int32[]> [-name] <String> [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Set-SnipeitCompany [-id] <Int32[]> [-name] <String> [[-image] <String>] [-image_delete] [-url] <String>
+ [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 4
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -56,6 +56,36 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -83,7 +113,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 3
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitCompany.md
+++ b/docs/Set-SnipeitCompany.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,7 +14,7 @@ Updates company name
 
 ```
 Set-SnipeitCompany [-id] <Int32[]> [-name] <String> [[-image] <String>] [-image_delete]
- [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-RequestType] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,14 +30,15 @@ An example
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 6
 Default value: None
 Accept pipeline input: False
@@ -121,14 +122,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 5
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitComponent.md
+++ b/docs/Set-SnipeitComponent.md
@@ -15,7 +15,8 @@ Updates component
 ```
 Set-SnipeitComponent [-id] <Int32[]> [-qty] <Int32> [[-min_amt] <Int32>] [[-name] <String>]
  [[-company_id] <Int32>] [[-location_id] <Int32>] [[-order_number] <String>] [[-purchase_date] <DateTime>]
- [[-purchase_cost] <Single>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-purchase_cost] <Single>] [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +40,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 11
+Position: 12
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -72,6 +73,36 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -189,7 +220,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 10
+Position: 11
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitComponent.md
+++ b/docs/Set-SnipeitComponent.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,8 +15,8 @@ Updates component
 ```
 Set-SnipeitComponent [-id] <Int32[]> [-qty] <Int32> [[-min_amt] <Int32>] [[-name] <String>]
  [[-company_id] <Int32>] [[-location_id] <Int32>] [[-order_number] <String>] [[-purchase_date] <DateTime>]
- [[-purchase_cost] <Single>] [[-image] <String>] [-image_delete] [[-RequestType] <String>] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-purchase_cost] <Single>] [[-image] <String>] [-image_delete] [[-RequestType] <String>] [[-url] <String>]
+ [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -26,20 +26,22 @@ Updates component on Snipe-It system
 
 ### EXAMPLE 1
 ```
-An example
+Set-SnipeitComponent -id 42 -qty 12
+Sets count of component with ID 42 to 12
 ```
 
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 13
 Default value: None
 Accept pipeline input: False
@@ -228,14 +230,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 12
 Default value: None
 Accept pipeline input: False
@@ -281,6 +284,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
-General notes
 
 ## RELATED LINKS

--- a/docs/Set-SnipeitComponent.md
+++ b/docs/Set-SnipeitComponent.md
@@ -15,8 +15,8 @@ Updates component
 ```
 Set-SnipeitComponent [-id] <Int32[]> [-qty] <Int32> [[-min_amt] <Int32>] [[-name] <String>]
  [[-company_id] <Int32>] [[-location_id] <Int32>] [[-order_number] <String>] [[-purchase_date] <DateTime>]
- [[-purchase_cost] <Single>] [[-image] <String>] [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [[-purchase_cost] <Single>] [[-image] <String>] [-image_delete] [[-RequestType] <String>] [-url] <String>
+ [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -40,7 +40,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 12
+Position: 13
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -211,6 +211,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 11
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -220,7 +236,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 11
+Position: 12
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitConsumable.md
+++ b/docs/Set-SnipeitConsumable.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -17,7 +17,7 @@ Set-SnipeitConsumable [-id] <Int32[]> [[-name] <String>] [[-qty] <Int32>] [[-cat
  [[-min_amt] <Int32>] [[-company_id] <Int32>] [[-order_number] <String>] [[-manufacturer_id] <Int32>]
  [[-location_id] <Int32>] [[-requestable] <Boolean>] [[-purchase_date] <DateTime>] [[-purchase_cost] <String>]
  [[-model_number] <String>] [[-item_no] <String>] [[-image] <String>] [-image_delete] [[-RequestType] <String>]
- [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,14 +34,15 @@ Create consumable with stock count 20 , alert when stock is  5 or lower
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 18
 Default value: None
 Accept pipeline input: False
@@ -305,14 +306,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 17
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitConsumable.md
+++ b/docs/Set-SnipeitConsumable.md
@@ -16,8 +16,8 @@ Add a new Consumable to Snipe-it asset system
 Set-SnipeitConsumable [-id] <Int32[]> [[-name] <String>] [[-qty] <Int32>] [[-category_id] <Int32>]
  [[-min_amt] <Int32>] [[-company_id] <Int32>] [[-order_number] <String>] [[-manufacturer_id] <Int32>]
  [[-location_id] <Int32>] [[-requestable] <Boolean>] [[-purchase_date] <DateTime>] [[-purchase_cost] <String>]
- [[-model_number] <String>] [[-item_no] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-model_number] <String>] [[-item_no] <String>] [[-image] <String>] [-image_delete] [-url] <String>
+ [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -42,7 +42,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 16
+Position: 17
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -89,6 +89,36 @@ Aliases:
 Required: True
 Position: 1
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 15
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -267,7 +297,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 15
+Position: 16
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitConsumable.md
+++ b/docs/Set-SnipeitConsumable.md
@@ -16,8 +16,8 @@ Add a new Consumable to Snipe-it asset system
 Set-SnipeitConsumable [-id] <Int32[]> [[-name] <String>] [[-qty] <Int32>] [[-category_id] <Int32>]
  [[-min_amt] <Int32>] [[-company_id] <Int32>] [[-order_number] <String>] [[-manufacturer_id] <Int32>]
  [[-location_id] <Int32>] [[-requestable] <Boolean>] [[-purchase_date] <DateTime>] [[-purchase_cost] <String>]
- [[-model_number] <String>] [[-item_no] <String>] [[-image] <String>] [-image_delete] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-model_number] <String>] [[-item_no] <String>] [[-image] <String>] [-image_delete] [[-RequestType] <String>]
+ [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -42,7 +42,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 17
+Position: 18
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -288,6 +288,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 16
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -297,7 +313,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 16
+Position: 17
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitCustomField.md
+++ b/docs/Set-SnipeitCustomField.md
@@ -15,7 +15,8 @@ Add a new Custom Field to Snipe-it asset system
 ```
 Set-SnipeitCustomField [-id] <Int32[]> [[-name] <String>] [[-help_text] <String>] [-element] <String>
  [[-format] <String>] [[-field_values] <String>] [[-field_encrypted] <Boolean>] [[-show_in_email] <Boolean>]
- [[-custom_format] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-custom_format] <String>] [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +40,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 11
+Position: 12
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -166,6 +167,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Put you could use Patch if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: Put
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -show_in_email
 Whether or not to show the custom field in email notifications
 
@@ -190,7 +207,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 10
+Position: 11
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitCustomField.md
+++ b/docs/Set-SnipeitCustomField.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,8 +15,8 @@ Add a new Custom Field to Snipe-it asset system
 ```
 Set-SnipeitCustomField [-id] <Int32[]> [[-name] <String>] [[-help_text] <String>] [-element] <String>
  [[-format] <String>] [[-field_values] <String>] [[-field_encrypted] <Boolean>] [[-show_in_email] <Boolean>]
- [[-custom_format] <String>] [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-custom_format] <String>] [[-RequestType] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -32,14 +32,15 @@ New-SnipeitCustomField -Name "AntivirusInstalled" -Format "BOOLEAN" -HelpText "I
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 12
 Default value: None
 Accept pipeline input: False
@@ -199,14 +200,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 11
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitDepartment.md
+++ b/docs/Set-SnipeitDepartment.md
@@ -14,8 +14,8 @@ Updates a department
 
 ```
 Set-SnipeitDepartment [-id] <Int32[]> [[-name] <String>] [[-company_id] <Int32>] [[-location_id] <Int32>]
- [[-manager_id] <Int32>] [[-notes] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-manager_id] <Int32>] [[-notes] <String>] [[-image] <String>] [-image_delete] [-url] <String>
+ [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +39,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 8
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -72,6 +72,36 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -144,7 +174,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 7
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitDepartment.md
+++ b/docs/Set-SnipeitDepartment.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,7 +15,7 @@ Updates a department
 ```
 Set-SnipeitDepartment [-id] <Int32[]> [[-name] <String>] [[-company_id] <Int32>] [[-location_id] <Int32>]
  [[-manager_id] <Int32>] [[-notes] <String>] [[-image] <String>] [-image_delete] [[-RequestType] <String>]
- [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -31,14 +31,15 @@ Set-SnipeitDepartment -id 4  -manager_id 3
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 10
 Default value: None
 Accept pipeline input: False
@@ -182,14 +183,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 9
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitDepartment.md
+++ b/docs/Set-SnipeitDepartment.md
@@ -14,8 +14,8 @@ Updates a department
 
 ```
 Set-SnipeitDepartment [-id] <Int32[]> [[-name] <String>] [[-company_id] <Int32>] [[-location_id] <Int32>]
- [[-manager_id] <Int32>] [[-notes] <String>] [[-image] <String>] [-image_delete] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-manager_id] <Int32>] [[-notes] <String>] [[-image] <String>] [-image_delete] [[-RequestType] <String>]
+ [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +39,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 9
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -165,6 +165,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -174,7 +190,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 8
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitInfo.md
+++ b/docs/Set-SnipeitInfo.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -8,16 +8,18 @@ schema: 2.0.0
 # Set-SnipeitInfo
 
 ## SYNOPSIS
-Sets authetication information
+Sets authetication information.
+Deprecated, use Connect-SnipeitPS instead.
 
 ## SYNTAX
 
 ```
-Set-SnipeitInfo [[-url] <Uri>] [[-apiKey] <String>] [<CommonParameters>]
+Set-SnipeitInfo [-url] <Uri> [-apiKey] <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Set apikey and url user to connect Snipe-It system
+Deprecated combatibilty function that Set apikey and url user to connect Snipe-It system.
+Please use Connect-SnipeitPS instead.
 
 ## EXAMPLES
 
@@ -29,14 +31,14 @@ Set-SnipeitInfo -url $url -apiKey -Verbose
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 2
 Default value: None
 Accept pipeline input: False
@@ -44,14 +46,14 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+URL of Snipeit system.
 
 ```yaml
 Type: Uri
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 1
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitLicense.md
+++ b/docs/Set-SnipeitLicense.md
@@ -18,7 +18,7 @@ Set-SnipeitLicense [-id] <Int32[]> [[-name] <String>] [[-seats] <Int32>] [[-cate
  [[-license_name] <String>] [[-maintained] <Boolean>] [[-manufacturer_id] <Int32>] [[-notes] <String>]
  [[-order_number] <String>] [[-purchase_cost] <Single>] [[-purchase_date] <DateTime>]
  [[-reassignable] <Boolean>] [[-serial] <String>] [[-supplier_id] <Int32>] [[-termination_date] <DateTime>]
- [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -42,7 +42,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 20
+Position: 21
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -258,6 +258,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 19
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -seats
 Number of license seats owned.
 
@@ -327,7 +343,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 19
+Position: 20
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitLicense.md
+++ b/docs/Set-SnipeitLicense.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -18,7 +18,7 @@ Set-SnipeitLicense [-id] <Int32[]> [[-name] <String>] [[-seats] <Int32>] [[-cate
  [[-license_name] <String>] [[-maintained] <Boolean>] [[-manufacturer_id] <Int32>] [[-notes] <String>]
  [[-order_number] <String>] [[-purchase_cost] <Single>] [[-purchase_date] <DateTime>]
  [[-reassignable] <Boolean>] [[-serial] <String>] [[-supplier_id] <Int32>] [[-termination_date] <DateTime>]
- [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-RequestType] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,14 +34,15 @@ Set-SnipeitLicence -name "License" -seats 3 -company_id 1
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 21
 Default value: None
 Accept pipeline input: False
@@ -335,14 +336,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 20
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitLicenseSeat.md
+++ b/docs/Set-SnipeitLicenseSeat.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,7 +14,7 @@ Set license seat or checkout license seat
 
 ```
 Set-SnipeitLicenseSeat [-id] <Int32[]> [-seat_id] <Int32> [[-assigned_to] <Int32>] [[-asset_id] <Int32>]
- [[-note] <String>] [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
+ [[-note] <String>] [[-RequestType] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -44,14 +44,15 @@ Checkin licence seat id 1 of licence id 1
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 8
 Default value: None
 Accept pipeline input: False
@@ -150,14 +151,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 7
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitLicenseSeat.md
+++ b/docs/Set-SnipeitLicenseSeat.md
@@ -14,7 +14,8 @@ Set license seat or checkout license seat
 
 ```
 Set-SnipeitLicenseSeat [-id] <Int32[]> [-seat_id] <Int32> [[-assigned_to] <Int32>] [[-asset_id] <Int32>]
- [[-note] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-note] <String>] [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -51,7 +52,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 7
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -117,6 +118,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -seat_id
 {{ Fill seat_id Description }}
 
@@ -141,7 +158,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 6
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitLicenseSeat.md
+++ b/docs/Set-SnipeitLicenseSeat.md
@@ -24,14 +24,20 @@ Checkout specific license seat to user, asset or both
 
 ### EXAMPLE 1
 ```
-Set-SnipeitLicenceSeat -ID 1 -seat_id 1 -assigned_id 3  -Verbose
+Set-SnipeitLicenceSeat -ID 1 -seat_id 1 -assigned_id 3
 Checkout licence to user id 3
 ```
 
 ### EXAMPLE 2
 ```
-Set-SnipeitLicenceSeat -ID 1 -seat_id 1 -asset_id 3  -Verbose
+Set-SnipeitLicenceSeat -ID 1 -seat_id 1 -asset_id 3
 Checkout licence to asset id 3
+```
+
+### EXAMPLE 3
+```
+Set-SnipeitLicenceSeat -ID 1 -seat_id 1 -asset_id $null -assigned_id $null
+Checkin licence seat id 1 of licence id 1
 ```
 
 ## PARAMETERS

--- a/docs/Set-SnipeitLocation.md
+++ b/docs/Set-SnipeitLocation.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -16,7 +16,7 @@ Updates Location in Snipe-it asset system
 Set-SnipeitLocation [-id] <Int32[]> [[-name] <String>] [[-address] <String>] [[-address2] <String>]
  [[-state] <String>] [[-country] <String>] [[-zip] <String>] [[-city] <String>] [[-currency] <String>]
  [[-manager_id] <Int32>] [[-ldap_ou] <String>] [[-parent_id] <Int32>] [[-image] <String>] [-image_delete]
- [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-RequestType] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -62,14 +62,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 16
 Default value: None
 Accept pipeline input: False
@@ -258,14 +259,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 15
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitLocation.md
+++ b/docs/Set-SnipeitLocation.md
@@ -16,7 +16,7 @@ Updates Location in Snipe-it asset system
 Set-SnipeitLocation [-id] <Int32[]> [[-name] <String>] [[-address] <String>] [[-address2] <String>]
  [[-state] <String>] [[-country] <String>] [[-zip] <String>] [[-city] <String>] [[-currency] <String>]
  [[-manager_id] <Int32>] [[-ldap_ou] <String>] [[-parent_id] <Int32>] [[-image] <String>] [-image_delete]
- [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -70,7 +70,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 15
+Position: 16
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -226,6 +226,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 14
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -state
 Address State
 
@@ -250,7 +266,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 14
+Position: 15
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitLocation.md
+++ b/docs/Set-SnipeitLocation.md
@@ -15,8 +15,8 @@ Updates Location in Snipe-it asset system
 ```
 Set-SnipeitLocation [-id] <Int32[]> [[-name] <String>] [[-address] <String>] [[-address2] <String>]
  [[-state] <String>] [[-country] <String>] [[-zip] <String>] [[-city] <String>] [[-currency] <String>]
- [[-manager_id] <Int32>] [[-ldap_ou] <String>] [[-parent_id] <Int32>] [-url] <String> [-apiKey] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-manager_id] <Int32>] [[-ldap_ou] <String>] [[-parent_id] <Int32>] [[-image] <String>] [-image_delete]
+ [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -70,7 +70,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 14
+Position: 15
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -133,6 +133,36 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 13
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -220,7 +250,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 13
+Position: 14
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitManufacturer.md
+++ b/docs/Set-SnipeitManufacturer.md
@@ -5,32 +5,32 @@ online version:
 schema: 2.0.0
 ---
 
-# New-SnipeitCompany
+# Set-SnipeitManufacturer
 
 ## SYNOPSIS
-Creates a new Company
+Add a new Manufacturer to Snipe-it asset system
 
 ## SYNTAX
 
 ```
-New-SnipeitCompany [-name] <String> [[-image] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Set-SnipeitManufacturer [-Name] <String> [[-image] <String>] [-image_delete] [[-RequestType] <String>]
+ [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Creates new company on Snipe-It system
+Long description
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
-New-SnipeitCompany -name "Acme Company"
+New-SnipeitManufacturer -name "HP"
 ```
 
 ## PARAMETERS
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Users API Key for Snipeit, can be set using Set-SnipeitInfo command
 
 ```yaml
 Type: String
@@ -38,14 +38,14 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 4
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -image
-Company image filename and path
+Image file name and path for item
 
 ```yaml
 Type: String
@@ -59,8 +59,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -name
-Comapany name
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Name of the Manufacturer
 
 ```yaml
 Type: String
@@ -74,6 +89,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -83,7 +114,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 3
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitManufacturer.md
+++ b/docs/Set-SnipeitManufacturer.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,7 +14,7 @@ Add a new Manufacturer to Snipe-it asset system
 
 ```
 Set-SnipeitManufacturer [-Name] <String> [[-image] <String>] [-image_delete] [[-RequestType] <String>]
- [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,14 +30,15 @@ New-SnipeitManufacturer -name "HP"
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 5
 Default value: None
 Accept pipeline input: False
@@ -106,14 +107,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 4
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitModel.md
+++ b/docs/Set-SnipeitModel.md
@@ -14,8 +14,8 @@ Updates Model on Snipe-it asset system
 
 ```
 Set-SnipeitModel [-id] <Int32[]> [[-name] <String>] [[-model_number] <String>] [[-category_id] <Int32>]
- [[-manufacturer_id] <Int32>] [[-eol] <Int32>] [[-custom_fieldset_id] <Int32>] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-manufacturer_id] <Int32>] [[-eol] <Int32>] [[-custom_fieldset_id] <Int32>] [[-image] <String>]
+ [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +39,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 9
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -105,6 +105,36 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -manufacturer_id
 Manufacturer ID that the asset belongs to this can be got using Get-Manufacturer
 
@@ -159,7 +189,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 8
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitModel.md
+++ b/docs/Set-SnipeitModel.md
@@ -15,7 +15,8 @@ Updates Model on Snipe-it asset system
 ```
 Set-SnipeitModel [-id] <Int32[]> [[-name] <String>] [[-model_number] <String>] [[-category_id] <Int32>]
  [[-manufacturer_id] <Int32>] [[-eol] <Int32>] [[-custom_fieldset_id] <Int32>] [[-image] <String>]
- [-image_delete] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-image_delete] [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +40,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 10
+Position: 11
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -180,6 +181,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -189,7 +206,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 9
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitModel.md
+++ b/docs/Set-SnipeitModel.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -15,7 +15,7 @@ Updates Model on Snipe-it asset system
 ```
 Set-SnipeitModel [-id] <Int32[]> [[-name] <String>] [[-model_number] <String>] [[-category_id] <Int32>]
  [[-manufacturer_id] <Int32>] [[-eol] <Int32>] [[-custom_fieldset_id] <Int32>] [[-image] <String>]
- [-image_delete] [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
+ [-image_delete] [[-RequestType] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -32,14 +32,15 @@ New-SnipeitModel -name "DL380" -manufacturer_id 2 -fieldset_id 2 -category_id 1
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 11
 Default value: None
 Accept pipeline input: False
@@ -198,14 +199,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 10
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitStatus.md
+++ b/docs/Set-SnipeitStatus.md
@@ -14,8 +14,8 @@ Sets  Snipe-it Status Labels
 
 ```
 Set-SnipeitStatus [-id] <Int32[]> [[-name] <String>] [-type] <String> [[-notes] <String>] [[-color] <String>]
- [[-show_in_nav] <Boolean>] [[-default_label] <Boolean>] [-url] <String> [-apiKey] <String> [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [[-show_in_nav] <Boolean>] [[-default_label] <Boolean>] [[-RequestType] <String>] [-url] <String>
+ [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,7 +44,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 9
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -125,6 +125,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -show_in_nav
 1 or 0 - determine whether the status label should show in the left-side nav of the web GUI
 
@@ -164,7 +180,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 8
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitStatus.md
+++ b/docs/Set-SnipeitStatus.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -14,8 +14,8 @@ Sets  Snipe-it Status Labels
 
 ```
 Set-SnipeitStatus [-id] <Int32[]> [[-name] <String>] [-type] <String> [[-notes] <String>] [[-color] <String>]
- [[-show_in_nav] <Boolean>] [[-default_label] <Boolean>] [[-RequestType] <String>] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-show_in_nav] <Boolean>] [[-default_label] <Boolean>] [[-RequestType] <String>] [[-url] <String>]
+ [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -36,14 +36,15 @@ Set-SnipeitStatus -id 3 -name 'Waiting for arrival' -type pending
 ## PARAMETERS
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 10
 Default value: None
 Accept pipeline input: False
@@ -172,14 +173,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 9
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitSupplier.md
+++ b/docs/Set-SnipeitSupplier.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -16,7 +16,7 @@ Modify the supplier
 Set-SnipeitSupplier [-name] <String> [[-address] <String>] [[-address2] <String>] [[-city] <String>]
  [[-state] <String>] [[-country] <String>] [[-zip] <String>] [[-phone] <String>] [[-fax] <String>]
  [[-email] <String>] [[-contact] <String>] [[-notes] <String>] [[-image] <String>] [-image_delete]
- [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-RequestType] <String>] [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -62,14 +62,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+Users API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 16
 Default value: None
 Accept pipeline input: False
@@ -258,14 +259,15 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 15
 Default value: None
 Accept pipeline input: False

--- a/docs/Set-SnipeitSupplier.md
+++ b/docs/Set-SnipeitSupplier.md
@@ -1,0 +1,330 @@
+---
+external help file: SnipeitPS-help.xml
+Module Name: SnipeitPS
+online version:
+schema: 2.0.0
+---
+
+# Set-SnipeitSupplier
+
+## SYNOPSIS
+Modify the supplier
+
+## SYNTAX
+
+```
+Set-SnipeitSupplier [-name] <String> [[-address] <String>] [[-address2] <String>] [[-city] <String>]
+ [[-state] <String>] [[-country] <String>] [[-zip] <String>] [[-phone] <String>] [[-fax] <String>]
+ [[-email] <String>] [[-contact] <String>] [[-notes] <String>] [[-image] <String>] [-image_delete]
+ [[-RequestType] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Modifieds the supplier on Snipe-It system
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+New-SnipeitDepartment -name "Department1" -company_id 1 -localtion_id 1 -manager_id 3
+```
+
+## PARAMETERS
+
+### -address
+Address line 1 of supplier
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -address2
+Address line 1 of supplier
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -apiKey
+Users API Key for Snipeit, can be set using Set-SnipeitInfo command
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 16
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -city
+City
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -contact
+Contact person
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 11
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -country
+Country
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -email
+Email address
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -fax
+Fax number
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 13
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -name
+Suppiers Name
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -notes
+Email address
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 12
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -phone
+Phone number
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 14
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -state
+State
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -url
+URL of Snipeit system, can be set using Set-SnipeitInfo command
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 15
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -zip
+Zip code
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/Set-SnipeitSupplier.md
+++ b/docs/Set-SnipeitSupplier.md
@@ -1,4 +1,4 @@
----
+﻿---
 external help file: SnipeitPS-help.xml
 Module Name: SnipeitPS
 online version:

--- a/docs/Set-SnipeitUser.md
+++ b/docs/Set-SnipeitUser.md
@@ -16,8 +16,8 @@ Creates a new user
 Set-SnipeitUser [-id] <Int32[]> [[-first_name] <String>] [[-last_name] <String>] [[-userName] <String>]
  [[-jobtitle] <String>] [[-email] <String>] [[-phone] <String>] [[-password] <String>] [[-company_id] <Int32>]
  [[-location_id] <Int32>] [[-department_id] <Int32>] [[-manager_id] <Int32>] [[-employee_num] <String>]
- [[-activated] <Boolean>] [[-notes] <String>] [[-image] <String>] [-image_delete] [-url] <String>
- [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-activated] <Boolean>] [[-notes] <String>] [[-image] <String>] [-image_delete] [[-RequestType] <String>]
+ [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -57,7 +57,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 18
+Position: 19
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -288,6 +288,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequestType
+Http request type to send Snipe IT system.
+Defaults to Patch you could use Put if needed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 17
+Default value: Patch
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -url
 URL of Snipeit system, can be set using Set-SnipeitInfo command
 
@@ -297,7 +313,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 17
+Position: 18
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitUser.md
+++ b/docs/Set-SnipeitUser.md
@@ -16,8 +16,8 @@ Creates a new user
 Set-SnipeitUser [-id] <Int32[]> [[-first_name] <String>] [[-last_name] <String>] [[-userName] <String>]
  [[-jobtitle] <String>] [[-email] <String>] [[-phone] <String>] [[-password] <String>] [[-company_id] <Int32>]
  [[-location_id] <Int32>] [[-department_id] <Int32>] [[-manager_id] <Int32>] [[-employee_num] <String>]
- [[-activated] <Boolean>] [[-notes] <String>] [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-activated] <Boolean>] [[-notes] <String>] [[-image] <String>] [-image_delete] [-url] <String>
+ [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -57,7 +57,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 17
+Position: 18
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -150,6 +150,36 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -image
+Image file name and path for item
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 16
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -image_delete
+Remove current image
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -267,7 +297,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 16
+Position: 17
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Set-SnipeitUser.md
+++ b/docs/Set-SnipeitUser.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---
@@ -13,11 +13,11 @@ Creates a new user
 ## SYNTAX
 
 ```
-Set-SnipeitUser [-id] <Int32[]> [[-first_name] <String>] [[-last_name] <String>] [[-userName] <String>]
+Set-SnipeitUser [-id] <Int32[]> [[-first_name] <String>] [[-last_name] <String>] [[-username] <String>]
  [[-jobtitle] <String>] [[-email] <String>] [[-phone] <String>] [[-password] <String>] [[-company_id] <Int32>]
  [[-location_id] <Int32>] [[-department_id] <Int32>] [[-manager_id] <Int32>] [[-employee_num] <String>]
  [[-activated] <Boolean>] [[-notes] <String>] [[-image] <String>] [-image_delete] [[-RequestType] <String>]
- [-url] <String> [-apiKey] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-url] <String>] [[-apiKey] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -49,14 +49,15 @@ Accept wildcard characters: False
 ```
 
 ### -apiKey
-User's API Key for Snipeit, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+User's API Key for Snipeit.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 19
 Default value: None
 Accept pipeline input: False
@@ -305,21 +306,22 @@ Accept wildcard characters: False
 ```
 
 ### -url
-URL of Snipeit system, can be set using Set-SnipeitInfo command
+Deprecated parameter, please use Connect-SnipeitPS instead.
+URL of Snipeit system.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 18
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -userName
+### -username
 Username for user
 
 ```yaml

--- a/docs/SnipeitPS.md
+++ b/docs/SnipeitPS.md
@@ -1,16 +1,19 @@
 ﻿---
-Module Name: SnipeitPS
+Module Name: snipeitps
 Module Guid: f86f4db4-1cb1-45c4-b7bf-6762531bfdeb
 Download Help Link: {{ Update Download Link }}
 Help Version: {{ Please enter version of help manually (X.X.X.X) format }}
 Locale: en-US
 ---
 
-# SnipeitPS Module
+# snipeitps Module
 ## Description
 {{ Fill in the Description }}
 
-## SnipeitPS Cmdlets
+## snipeitps Cmdlets
+### [Connect-SnipeitPS](Connect-SnipeitPS.md)
+Sets authetication information
+
 ### [Get-SnipeitAccessory](Get-SnipeitAccessory.md)
 Gets a list of Snipe-it Accessories
 
@@ -192,7 +195,8 @@ Add a new Custom Field to Snipe-it asset system
 Updates a department
 
 ### [Set-SnipeitInfo](Set-SnipeitInfo.md)
-Sets authetication information
+Sets authetication information.
+Deprecated, use Connect-SnipeitPS instead.
 
 ### [Set-SnipeitLicense](Set-SnipeitLicense.md)
 Updates a licence

--- a/docs/SnipeitPS.md
+++ b/docs/SnipeitPS.md
@@ -104,6 +104,9 @@ Add a new Manufacturer to Snipe-it asset system
 ### [New-SnipeitModel](New-SnipeitModel.md)
 Add a new Model to Snipe-it asset system
 
+### [New-SnipeitSupplier](New-SnipeitSupplier.md)
+Creates a supplier
+
 ### [New-SnipeitUser](New-SnipeitUser.md)
 Creates a new user
 
@@ -145,6 +148,9 @@ Removes manufacturer from Snipe-it asset system
 
 ### [Remove-SnipeitModel](Remove-SnipeitModel.md)
 Removes Asset model from Snipe-it asset system
+
+### [Remove-SnipeitSupplier](Remove-SnipeitSupplier.md)
+Removes supplier from Snipe-it asset system
 
 ### [Remove-SnipeitUser](Remove-SnipeitUser.md)
 Removes User from Snipe-it asset system
@@ -197,11 +203,17 @@ Set license seat or checkout license seat
 ### [Set-SnipeitLocation](Set-SnipeitLocation.md)
 Updates Location in Snipe-it asset system
 
+### [Set-SnipeitManufacturer](Set-SnipeitManufacturer.md)
+Add a new Manufacturer to Snipe-it asset system
+
 ### [Set-SnipeitModel](Set-SnipeitModel.md)
 Updates Model on Snipe-it asset system
 
 ### [Set-SnipeitStatus](Set-SnipeitStatus.md)
 Sets  Snipe-it Status Labels
+
+### [Set-SnipeitSupplier](Set-SnipeitSupplier.md)
+Modify the supplier
 
 ### [Set-SnipeitUser](Set-SnipeitUser.md)
 Creates a new user

--- a/docs/Update-SnipeitAlias.md
+++ b/docs/Update-SnipeitAlias.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: SnipeitPS-help.xml
-Module Name: SnipeitPS
+Module Name: snipeitps
 online version:
 schema: 2.0.0
 ---

--- a/docs/about_SnipeitPS.md
+++ b/docs/about_SnipeitPS.md
@@ -10,7 +10,9 @@ Collection of tools that makes interacting with Snipe-it api more pleasant.
 # EXAMPLES
 Prepare connection Snipe-It with:
 
-Set-SnipeitInfo -url https://your.site -apikey YourVeryLongApiKey....
+Connect-SnipeitPS -url https://your.site -apikey YourVeryLongApiKey....
+
+For secure ways to pass apikey to script, see Get-Help Connect-SnipeitPS -full
 
 To search assets use:
 


### PR DESCRIPTION
New Connect-SnipeitPS command to replace Set-SnipeitInfo.

Deprecated -url and -apiKey parameters for all other functions that Connect-SnipeitPS. There's still compatibility alias from  set-snipeitinfo to  Connect-SnipeitPS.

Fix content encoding bug introduced when releasing v.1.9