### PR TITLE
Fixed #234 , keep id parameter for recursive calls

### DIFF
--- a/SnipeitPS/Public/Get-SnipeitLicenseSeat.ps1
+++ b/SnipeitPS/Public/Get-SnipeitLicenseSeat.ps1
@@ -56,7 +56,7 @@ function Get-SnipeitLicenseSeat() {
     begin {
         Test-SnipeitAlias -invocationName $MyInvocation.InvocationName -commandName $MyInvocation.MyCommand.Name
 
-        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
+        $SearchParameter = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters -DefaultExcludeParameter 'url', 'apiKey', 'Debug', 'Verbose','RequestType'
 
         $api = "/api/v1/licenses/$id/seats"
 


### PR DESCRIPTION
Fixed #234 , keep id parameter for recursive calls