### PR TITLE
Fixed Typo

### DIFF
--- a/SnipeitPS/Public/New-SnipeitLicense.ps1
+++ b/SnipeitPS/Public/New-SnipeitLicense.ps1
@@ -89,7 +89,6 @@ function New-SnipeitLicense() {
 
         [datetime]$expiration_date,
 
-        [ValidateLength(1, 120)]
         [mailaddress]$license_email,
 
         [ValidateLength(1, 100)]

--- a/SnipeitPS/Public/New-SnipeitSupplier.ps1
+++ b/SnipeitPS/Public/New-SnipeitSupplier.ps1
@@ -102,7 +102,7 @@ function New-SnipeitSupplier() {
         $Values = . Get-ParameterValue -Parameters $MyInvocation.MyCommand.Parameters -BoundParameters $PSBoundParameters
 
         $Parameters = @{
-            Api    = "/api/v1/suppilers"
+            Api    = "/api/v1/suppliers"
             Method = 'POST'
             Body   = $Values
         }


### PR DESCRIPTION
Typo was causing New-SnipeitSupplier to fail with "Method Not Allowed"